### PR TITLE
Switch release workflow to Amazon ECR public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release ARM64 Images
+name: ECR Release Workflow
 
 on:
   push:
@@ -12,6 +12,9 @@ on:
 jobs:
   build-riva-arm64:
     runs-on: ubuntu-22.04-arm
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
@@ -19,20 +22,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: openmindagi/riva-speech-server
+          images: public.ecr.aws/b8k9c8n5/openmind/riva-speech-server
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -49,28 +57,39 @@ jobs:
           file: ./docker/Dockerfile.riva
           platforms: linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=openmindagi/riva-speech-server,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=public.ecr.aws/b8k9c8n5/openmind/riva-speech-server,push-by-digest=true,name-canonical=true,push=true
 
   build-embedding-arm64:
     runs-on: ubuntu-22.04-arm
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
       metadata: ${{ steps.meta.outputs.json }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: openmindagi/embedding_service
+          images: public.ecr.aws/b8k9c8n5/openmind/embedding_service
           tags: |
             type=semver,pattern={{version}},prefix=v
             type=semver,pattern={{major}}.{{minor}},prefix=v
@@ -78,6 +97,7 @@ jobs:
             type=sha
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=e5-small-v2-aarch64
+
       - name: Build and push ARM64 image by digest
         id: build
         uses: docker/build-push-action@v4
@@ -86,20 +106,32 @@ jobs:
           file: ./docker/Dockerfile.embed
           platforms: linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=openmindagi/embedding_service,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=public.ecr.aws/b8k9c8n5/openmind/embedding_service,push-by-digest=true,name-canonical=true,push=true
 
   create-riva-manifest:
     runs-on: ubuntu-latest
     needs: [build-riva-arm64]
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    environment:
+      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production-riva' || 'staging-riva' }}
+      url: https://gallery.ecr.aws/b8k9c8n5/openmind/riva-speech-server
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Create manifest list and push
         run: |
@@ -112,20 +144,34 @@ jobs:
 
             docker buildx imagetools create \
               --tag $tag \
-              openmindagi/riva-speech-server@${{ needs.build-riva-arm64.outputs.image-digest }}
+              public.ecr.aws/b8k9c8n5/openmind/riva-speech-server@${{ needs.build-riva-arm64.outputs.image-digest }}
           done
 
   create-embedding-manifest:
     runs-on: ubuntu-latest
     needs: [build-embedding-arm64]
+    permissions:
+      id-token: write
+      contents: read
+      deployments: write
+    environment:
+      name: ${{ startsWith(github.ref, 'refs/tags/v') && 'production-embedding' || 'staging-embedding' }}
+      url: https://gallery.ecr.aws/b8k9c8n5/openmind/embedding_service
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
       - name: Create manifest list and push
         run: |
           tags=$(echo '${{ needs.build-embedding-arm64.outputs.metadata }}' | jq -r '.tags[]')
@@ -133,5 +179,5 @@ jobs:
             echo "Creating manifest for: $tag"
             docker buildx imagetools create \
               --tag $tag \
-              openmindagi/embedding_service@${{ needs.build-embedding-arm64.outputs.image-digest }}
+              public.ecr.aws/b8k9c8n5/openmind/embedding_service@${{ needs.build-embedding-arm64.outputs.image-digest }}
           done


### PR DESCRIPTION
Replace Docker Hub publishing with Amazon ECR Public across release workflow. Add aws-actions/configure-aws-credentials and amazon-ecr-login usage, update registry paths to public.ecr.aws/b8k9c8n5/openmind/*, and adjust build/push outputs accordingly. Bump actions (checkout, setup-buildx) versions, add required permissions (id-token, contents, deployments) and environment metadata for manifest jobs, and ensure images are created/pushed via ECR public. These changes enable publishing ARM64 images to ECR Public with proper AWS role assumption and updated tooling.