### PR TITLE
Mock cv2.imencode to return numpy array

### DIFF
--- a/tests/om1_vlm/video/test_video_stream.py
+++ b/tests/om1_vlm/video/test_video_stream.py
@@ -53,8 +53,10 @@ class MockVideoCapture:
 def mock_cv2():
     with patch("cv2.VideoCapture", MockVideoCapture) as mock:
         with patch("cv2.imencode") as mock_imencode:
-            # Mock imencode to return a simple base64 string
-            mock_imencode.return_value = (True, b"fake_image_data")
+            mock_imencode.return_value = (
+                True,
+                np.frombuffer(b"fake_image_data", dtype=np.uint8),
+            )
             yield mock
 
 


### PR DESCRIPTION
Update the test fixture in tests/om1_vlm/video/test_video_stream.py so that the mocked cv2.imencode returns a numpy.uint8 array (np.frombuffer(..., dtype=np.uint8)) instead of raw bytes. This makes the mock match the real cv2.imencode return type (success flag, ndarray) and avoids type mismatches in the tests.