### PR TITLE
Upload unknown person

### DIFF
--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -16,7 +16,6 @@ Usage:
 
 from __future__ import annotations
 
-import base64
 import logging
 import time
 from collections import Counter
@@ -60,7 +59,6 @@ class _TrackIdentity:
     recog_attempts: int = 0
     # Unknown capture state
     unknown_since: float = 0.0  # when status first became unknown (0 = not unknown)
-    capture_count: int = 0  # 1 = already captured, 0 = not yet
 
 
 class FaceTracker:
@@ -568,96 +566,36 @@ class FaceTracker:
         """
         return self._current_faces
 
-    def get_unknown_captures(
-        self,
-        frame: np.ndarray,
-        track_results: List[TrackResult],
-        unknown_persist_sec: float = 5.0,
-        min_area_ratio: float = 0.003,
-        jpeg_quality: int = 80,
-    ) -> Optional[dict]:
-        """Check if any unknown tracks qualify for capture.
-
-        Each unknown track gets captured exactly ONCE after being unknown
-        for >= unknown_persist_sec with bbox area >= min_area_ratio.
+    def get_unknowns(self) -> list:
+        """Get all unknown faces in current frame with duration info.
 
         Returns
         -------
-        dict or None
-            None if no tracks qualify. Otherwise:
-            {
-                "frame_b64": str,
-                "timestamp": float,
-                "frame_hw": [H, W],
-                "unknown_captures": [
-                    {"track_id": int, "bbox": [x1,y1,x2,y2], "area": int,
-                     "unknown_duration": float},
-                    ...
-                ]
-            }
+        list of dict
+            Each dict has 'track_id', 'bbox', 'area', 'unknown_duration'.
+            Empty list if no unknowns.
         """
         now = time.time()
-        H, W = frame.shape[:2]
-        min_area = H * W * min_area_ratio
+        unknowns = []
 
-        qualifying = []
-
-        for tr in track_results:
-            if tr.is_known or (tr.name is not None and tr.name != "unknown"):
+        for face in self._current_faces:
+            if face["name"] != "unknown":
                 continue
-
-            ident = self._identities.get(tr.track_id)
+            tid = face["track_id"]
+            ident = self._identities.get(tid)
             if ident is None or ident.unknown_since <= 0:
                 continue
 
-            # Already captured once → skip
-            if ident.capture_count > 0:
-                continue
-
-            unknown_duration = now - ident.unknown_since
-            if unknown_duration < unknown_persist_sec:
-                continue
-
-            x1, y1, x2, y2 = tr.bbox
-            area = (x2 - x1) * (y2 - y1)
-            if area < min_area:
-                continue
-
-            qualifying.append(
+            unknowns.append(
                 {
-                    "track_id": tr.track_id,
-                    "bbox": [int(x1), int(y1), int(x2), int(y2)],
-                    "area": int(area),
-                    "unknown_duration": round(unknown_duration, 1),
+                    "track_id": tid,
+                    "bbox": list(face["bbox"]),
+                    "area": face["area"],
+                    "unknown_duration": round(now - ident.unknown_since, 1),
                 }
             )
 
-        if not qualifying:
-            return None
-
-        ok, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality])
-        if not ok:
-            return None
-        frame_b64 = base64.b64encode(buf.tobytes()).decode("ascii")
-
-        for q in qualifying:
-            ident = self._identities.get(q["track_id"])
-            if ident:
-                ident.capture_count = 1
-
-        log.info(
-            "Unknown capture: %d tracks [%s], frame %.1fKB",
-            len(qualifying),
-            ", ".join(f"T{q['track_id']}" for q in qualifying),
-            len(frame_b64) / 1024,
-        )
-
-        return {
-            "frame_b64": frame_b64,
-            "timestamp": now,
-            "frame_hw": [H, W],
-            "unknown_captures": qualifying,
-        }
+        return unknowns
 
     def reset(self) -> None:
         """Reset all tracking state."""

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -60,8 +60,7 @@ class _TrackIdentity:
     recog_attempts: int = 0
     # Unknown capture state
     unknown_since: float = 0.0  # when status first became unknown (0 = not unknown)
-    last_capture_time: float = 0.0  # last time we sent a capture for this track
-    capture_count: int = 0  # total captures sent
+    capture_count: int = 0  # 1 = already captured, 0 = not yet
 
 
 class FaceTracker:
@@ -523,7 +522,7 @@ class FaceTracker:
             ident.status = "identified"
             ident.name = best_name
             ident.sim = avg_sim
-            ident.unknown_since = 0  # reset unknown timer
+            ident.unknown_since = 0  # no longer unknown
             log.info(
                 f"Track {ident.track_id}: confirmed '{best_name}' "
                 f"(votes={best_count}/{total_votes}, sim={avg_sim:.3f})"
@@ -575,19 +574,12 @@ class FaceTracker:
         track_results: List[TrackResult],
         unknown_persist_sec: float = 5.0,
         min_area_ratio: float = 0.003,
-        capture_interval_sec: float = 5.0,
-        max_captures_per_track: int = 10,
         jpeg_quality: int = 80,
     ) -> Optional[dict]:
         """Check if any unknown tracks qualify for capture.
 
-        Returns 1 frame_b64 + list of all qualifying unknown bboxes.
-
-        Criteria per track (ALL must be met):
-          - status == "unknown" consistently for >= unknown_persist_sec
-          - bbox area >= min_area_ratio of frame area (default 0.3%)
-          - time since last capture for this track >= capture_interval_sec
-          - total captures for this track < max_captures_per_track
+        Each unknown track gets captured exactly ONCE after being unknown
+        for >= unknown_persist_sec with bbox area >= min_area_ratio.
 
         Returns
         -------
@@ -599,15 +591,14 @@ class FaceTracker:
                 "frame_hw": [H, W],
                 "unknown_captures": [
                     {"track_id": int, "bbox": [x1,y1,x2,y2], "area": int,
-                     "unknown_duration": float, "capture_num": int},
+                     "unknown_duration": float},
                     ...
                 ]
             }
         """
         now = time.time()
         H, W = frame.shape[:2]
-        frame_area = H * W
-        min_area = frame_area * min_area_ratio
+        min_area = H * W * min_area_ratio
 
         qualifying = []
 
@@ -616,11 +607,13 @@ class FaceTracker:
                 continue
 
             ident = self._identities.get(tr.track_id)
-            if ident is None:
+            if ident is None or ident.unknown_since <= 0:
                 continue
 
-            if ident.unknown_since <= 0:
+            # Already captured once → skip
+            if ident.capture_count > 0:
                 continue
+
             unknown_duration = now - ident.unknown_since
             if unknown_duration < unknown_persist_sec:
                 continue
@@ -630,21 +623,12 @@ class FaceTracker:
             if area < min_area:
                 continue
 
-            if ident.capture_count >= max_captures_per_track:
-                continue
-            if (
-                ident.last_capture_time > 0
-                and (now - ident.last_capture_time) < capture_interval_sec
-            ):
-                continue
-
             qualifying.append(
                 {
                     "track_id": tr.track_id,
                     "bbox": [int(x1), int(y1), int(x2), int(y2)],
                     "area": int(area),
                     "unknown_duration": round(unknown_duration, 1),
-                    "capture_num": ident.capture_count + 1,
                 }
             )
 
@@ -659,8 +643,7 @@ class FaceTracker:
         for q in qualifying:
             ident = self._identities.get(q["track_id"])
             if ident:
-                ident.last_capture_time = now
-                ident.capture_count += 1
+                ident.capture_count = 1
 
         log.info(
             "Unknown capture: %d tracks [%s], frame %.1fKB",

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -125,6 +125,9 @@ class FaceTracker:
         # Track IDs seen this frame (for cleanup)
         self._active_ids: set = set()
 
+        # Current frame faces (for status queries)
+        self._current_faces: list = []
+
     @staticmethod
     def _init_tracker(track_buffer: int, det_conf: float = 0.5):
         """Initialize BoTSORT tracker with thresholds aligned to detection confidence."""
@@ -288,6 +291,22 @@ class FaceTracker:
 
         # Cleanup stale tracks
         self._cleanup_stale()
+
+        # Build faces sorted by bbox area (largest = closest first)
+        faces = []
+        for r in results:
+            x1, y1, x2, y2 = r.bbox
+            area = (x2 - x1) * (y2 - y1)
+            ident = self._identities.get(r.track_id)
+            name = ident.name if ident and ident.status == "identified" else "unknown"
+            faces.append(
+                {
+                    "name": name,
+                    "bbox": r.bbox,
+                    "area": area,
+                }
+            )
+        self._current_faces = sorted(faces, key=lambda f: f["area"], reverse=True)
 
         return results
 
@@ -504,7 +523,7 @@ class FaceTracker:
             ident.status = "identified"
             ident.name = best_name
             ident.sim = avg_sim
-            ident.unknown_since = 0  # reset — no longer unknown
+            ident.unknown_since = 0  # reset unknown timer
             log.info(
                 f"Track {ident.track_id}: confirmed '{best_name}' "
                 f"(votes={best_count}/{total_votes}, sim={avg_sim:.3f})"
@@ -539,6 +558,17 @@ class FaceTracker:
             if tid in self._active_ids
         }
 
+    def get_faces(self) -> list:
+        """Get all faces sorted by bbox area (largest first).
+
+        Returns
+        -------
+        list of dict
+            Each dict has 'name' (str), 'bbox' (tuple), 'area' (int).
+            Empty list if no faces in current frame.
+        """
+        return self._current_faces
+
     def get_unknown_captures(
         self,
         frame: np.ndarray,
@@ -549,37 +579,22 @@ class FaceTracker:
         max_captures_per_track: int = 10,
         jpeg_quality: int = 80,
     ) -> Optional[dict]:
-        """Check if any unknown tracks qualify for capture and return frame + bbox list.
+        """Check if any unknown tracks qualify for capture.
+
+        Returns 1 frame_b64 + list of all qualifying unknown bboxes.
 
         Criteria per track (ALL must be met):
           - status == "unknown" consistently for >= unknown_persist_sec
           - bbox area >= min_area_ratio of frame area (default 0.3%)
-          - time since last capture >= capture_interval_sec
-          - total captures < max_captures_per_track
-
-        Parameters
-        ----------
-        frame : ndarray (H, W, 3)
-            Current BGR frame (will be JPEG-encoded once if any track qualifies).
-        track_results : list[TrackResult]
-            Current frame's track results from update().
-        unknown_persist_sec : float
-            Seconds the track must remain unknown before first capture.
-        min_area_ratio : float
-            Minimum bbox area as fraction of frame area (0.003 = 0.3%).
-        capture_interval_sec : float
-            Minimum seconds between captures for the same track.
-        max_captures_per_track : int
-            Stop capturing after this many sends per track.
-        jpeg_quality : int
-            JPEG encode quality for frame_b64.
+          - time since last capture for this track >= capture_interval_sec
+          - total captures for this track < max_captures_per_track
 
         Returns
         -------
         dict or None
             None if no tracks qualify. Otherwise:
             {
-                "frame_b64": str,          # JPEG base64 of full frame
+                "frame_b64": str,
                 "timestamp": float,
                 "frame_hw": [H, W],
                 "unknown_captures": [
@@ -597,7 +612,6 @@ class FaceTracker:
         qualifying = []
 
         for tr in track_results:
-            # Must be unknown
             if tr.is_known or (tr.name is not None and tr.name != "unknown"):
                 continue
 
@@ -605,20 +619,17 @@ class FaceTracker:
             if ident is None:
                 continue
 
-            # Must have been unknown long enough
             if ident.unknown_since <= 0:
                 continue
             unknown_duration = now - ident.unknown_since
             if unknown_duration < unknown_persist_sec:
                 continue
 
-            # BBox area check
             x1, y1, x2, y2 = tr.bbox
             area = (x2 - x1) * (y2 - y1)
             if area < min_area:
                 continue
 
-            # Rate limit per track
             if ident.capture_count >= max_captures_per_track:
                 continue
             if (
@@ -640,13 +651,11 @@ class FaceTracker:
         if not qualifying:
             return None
 
-        # Encode frame once for all qualifying tracks
         ok, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality])
         if not ok:
             return None
         frame_b64 = base64.b64encode(buf.tobytes()).decode("ascii")
 
-        # Update capture state
         for q in qualifying:
             ident = self._identities.get(q["track_id"])
             if ident:

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -220,6 +220,12 @@ class FaceTracker:
             ident = self._identities[track_id]
             ident.frames_seen += 1
 
+            # Track how long this face has been unknown
+            if ident.status == "identified":
+                ident.unknown_since = 0.0  # reset when identified
+            elif ident.unknown_since == 0.0:
+                ident.unknown_since = now  # start timing
+
             # Re-identify: if "unknown" or low-confidence "identified" and enough
             # time has passed, reset voting state so recognition retries.
             # Handles the "walking closer" scenario where face gets clearer over time.

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -16,6 +16,7 @@ Usage:
 
 from __future__ import annotations
 
+import base64
 import logging
 import time
 from collections import Counter
@@ -57,8 +58,10 @@ class _TrackIdentity:
     last_recog_time: float = 0.0
     frames_seen: int = 0
     recog_attempts: int = 0
-    # Unknown duration tracking (0.0 = not unknown)
-    unknown_since: float = 0.0
+    # Unknown capture state
+    unknown_since: float = 0.0  # when status first became unknown (0 = not unknown)
+    last_capture_time: float = 0.0  # last time we sent a capture for this track
+    capture_count: int = 0  # total captures sent
 
 
 class FaceTracker:
@@ -121,21 +124,6 @@ class FaceTracker:
 
         # Track IDs seen this frame (for cleanup)
         self._active_ids: set = set()
-
-        # Current frame faces sorted by area (for /who)
-        self._current_faces: list = []
-
-        # Unknown capture: track_ids already captured (no repeat upload)
-        self._uploaded_unknown_ids: set = set()
-
-        # Frame dimensions (set on first update)
-        self._frame_area: int = 0
-
-        # Min bbox area ratio to qualify for unknown capture (0.3%)
-        self._unknown_area_ratio: float = 0.003
-
-        # Seconds an unknown must persist before capture
-        self._unknown_capture_delay: float = 5.0
 
     @staticmethod
     def _init_tracker(track_buffer: int, det_conf: float = 0.5):
@@ -232,15 +220,9 @@ class FaceTracker:
             ident = self._identities[track_id]
             ident.frames_seen += 1
 
-            # Track how long this face has been unknown
-            if ident.status == "identified":
-                ident.unknown_since = 0.0  # reset when identified
-            elif ident.unknown_since == 0.0:
-                ident.unknown_since = now  # start timing
-
             # Re-identify: if "unknown" or low-confidence "identified" and enough
             # time has passed, reset voting state so recognition retries.
-            # High-confidence identified tracks are NOT re-verified.
+            # Handles the "walking closer" scenario where face gets clearer over time.
             if (
                 self.re_identify_interval > 0
                 and (now - ident.last_recog_time) >= self.re_identify_interval
@@ -306,26 +288,6 @@ class FaceTracker:
 
         # Cleanup stale tracks
         self._cleanup_stale()
-
-        # Update frame area for unknown capture threshold
-        self._frame_area = H * W
-
-        # Build faces sorted by bbox area (largest = closest first)
-        faces = []
-        for r in results:
-            x1, y1, x2, y2 = r.bbox
-            area = (x2 - x1) * (y2 - y1)
-            ident = self._identities.get(r.track_id)
-            name = ident.name if ident and ident.status == "identified" else "unknown"
-            faces.append(
-                {
-                    "name": name,
-                    "bbox": r.bbox,
-                    "area": area,
-                    "track_id": r.track_id,
-                }
-            )
-        self._current_faces = sorted(faces, key=lambda f: f["area"], reverse=True)
 
         return results
 
@@ -509,9 +471,13 @@ class FaceTracker:
 
     def _finalize_identity(self, ident: _TrackIdentity) -> None:
         """Decide identity from collected votes using majority voting."""
+        now = time.time()
+
         if not ident.vote_names:
             ident.status = "unknown"
             ident.name = None
+            if ident.unknown_since == 0:
+                ident.unknown_since = now
             return
 
         real_votes = [n for n in ident.vote_names if n != "__unknown__"]
@@ -519,6 +485,8 @@ class FaceTracker:
         if not real_votes:
             ident.status = "unknown"
             ident.name = None
+            if ident.unknown_since == 0:
+                ident.unknown_since = now
             log.debug(f"Track {ident.track_id}: all votes unknown")
             return
 
@@ -536,7 +504,7 @@ class FaceTracker:
             ident.status = "identified"
             ident.name = best_name
             ident.sim = avg_sim
-            ident.unknown_since = 0.0  # no longer unknown
+            ident.unknown_since = 0  # reset — no longer unknown
             log.info(
                 f"Track {ident.track_id}: confirmed '{best_name}' "
                 f"(votes={best_count}/{total_votes}, sim={avg_sim:.3f})"
@@ -544,6 +512,8 @@ class FaceTracker:
         else:
             ident.status = "unknown"
             ident.name = None
+            if ident.unknown_since == 0:
+                ident.unknown_since = now
             log.debug(
                 f"Track {ident.track_id}: no majority ({best_name} {best_count}/{total_votes})"
             )
@@ -569,78 +539,138 @@ class FaceTracker:
             if tid in self._active_ids
         }
 
-    def get_faces(self) -> list:
-        """Get all faces sorted by bbox area (largest first).
+    def get_unknown_captures(
+        self,
+        frame: np.ndarray,
+        track_results: List[TrackResult],
+        unknown_persist_sec: float = 5.0,
+        min_area_ratio: float = 0.003,
+        capture_interval_sec: float = 5.0,
+        max_captures_per_track: int = 10,
+        jpeg_quality: int = 80,
+    ) -> Optional[dict]:
+        """Check if any unknown tracks qualify for capture and return frame + bbox list.
 
-        Returns
-        -------
-        list of dict
-            Each dict has 'name' (str), 'bbox' (tuple), 'area' (int).
-            Empty list if no faces in current frame.
-        """
-        return [
-            {"name": f["name"], "bbox": f["bbox"], "area": f["area"]}
-            for f in self._current_faces
-        ]
+        Criteria per track (ALL must be met):
+          - status == "unknown" consistently for >= unknown_persist_sec
+          - bbox area >= min_area_ratio of frame area (default 0.3%)
+          - time since last capture >= capture_interval_sec
+          - total captures < max_captures_per_track
 
-    def get_capturable_unknown(self) -> Optional[dict]:
-        """Get an unknown face eligible for capture/upload.
-
-        Conditions:
-        - Status is not "identified" (unknown/new/identifying)
-        - Unknown for >= _unknown_capture_delay seconds (default 5s)
-        - Bbox area >= _unknown_area_ratio of frame area (default 0.3%)
-        - Not already captured (track_id not in _uploaded_unknown_ids)
+        Parameters
+        ----------
+        frame : ndarray (H, W, 3)
+            Current BGR frame (will be JPEG-encoded once if any track qualifies).
+        track_results : list[TrackResult]
+            Current frame's track results from update().
+        unknown_persist_sec : float
+            Seconds the track must remain unknown before first capture.
+        min_area_ratio : float
+            Minimum bbox area as fraction of frame area (0.003 = 0.3%).
+        capture_interval_sec : float
+            Minimum seconds between captures for the same track.
+        max_captures_per_track : int
+            Stop capturing after this many sends per track.
+        jpeg_quality : int
+            JPEG encode quality for frame_b64.
 
         Returns
         -------
         dict or None
-            {'track_id': int, 'bbox': tuple, 'area': int, 'timestamp': float}
-            or None if no eligible unknown.
+            None if no tracks qualify. Otherwise:
+            {
+                "frame_b64": str,          # JPEG base64 of full frame
+                "timestamp": float,
+                "frame_hw": [H, W],
+                "unknown_captures": [
+                    {"track_id": int, "bbox": [x1,y1,x2,y2], "area": int,
+                     "unknown_duration": float, "capture_num": int},
+                    ...
+                ]
+            }
         """
-        if self._frame_area == 0:
-            return None
-
         now = time.time()
-        min_area = self._frame_area * self._unknown_area_ratio
+        H, W = frame.shape[:2]
+        frame_area = H * W
+        min_area = frame_area * min_area_ratio
 
-        for face in self._current_faces:
-            if face["name"] != "unknown":
-                continue
-            if face["area"] < min_area:
+        qualifying = []
+
+        for tr in track_results:
+            # Must be unknown
+            if tr.is_known or (tr.name is not None and tr.name != "unknown"):
                 continue
 
-            tid = face["track_id"]
-            ident = self._identities.get(tid)
+            ident = self._identities.get(tr.track_id)
             if ident is None:
                 continue
-            if tid in self._uploaded_unknown_ids:
+
+            # Must have been unknown long enough
+            if ident.unknown_since <= 0:
                 continue
-            if ident.unknown_since == 0.0:
-                continue
-            if (now - ident.unknown_since) < self._unknown_capture_delay:
+            unknown_duration = now - ident.unknown_since
+            if unknown_duration < unknown_persist_sec:
                 continue
 
-            return {
-                "track_id": tid,
-                "bbox": face["bbox"],
-                "area": face["area"],
-                "timestamp": now,
-            }
+            # BBox area check
+            x1, y1, x2, y2 = tr.bbox
+            area = (x2 - x1) * (y2 - y1)
+            if area < min_area:
+                continue
 
-        return None
+            # Rate limit per track
+            if ident.capture_count >= max_captures_per_track:
+                continue
+            if (
+                ident.last_capture_time > 0
+                and (now - ident.last_capture_time) < capture_interval_sec
+            ):
+                continue
 
-    def mark_captured(self, track_id: int) -> None:
-        """Mark a track_id as captured so it won't be captured again."""
-        self._uploaded_unknown_ids.add(track_id)
-        log.info(f"Track {track_id}: marked as captured for upload")
+            qualifying.append(
+                {
+                    "track_id": tr.track_id,
+                    "bbox": [int(x1), int(y1), int(x2), int(y2)],
+                    "area": int(area),
+                    "unknown_duration": round(unknown_duration, 1),
+                    "capture_num": ident.capture_count + 1,
+                }
+            )
+
+        if not qualifying:
+            return None
+
+        # Encode frame once for all qualifying tracks
+        ok, buf = cv2.imencode(".jpg", frame, [cv2.IMWRITE_JPEG_QUALITY, jpeg_quality])
+        if not ok:
+            return None
+        frame_b64 = base64.b64encode(buf.tobytes()).decode("ascii")
+
+        # Update capture state
+        for q in qualifying:
+            ident = self._identities.get(q["track_id"])
+            if ident:
+                ident.last_capture_time = now
+                ident.capture_count += 1
+
+        log.info(
+            "Unknown capture: %d tracks [%s], frame %.1fKB",
+            len(qualifying),
+            ", ".join(f"T{q['track_id']}" for q in qualifying),
+            len(frame_b64) / 1024,
+        )
+
+        return {
+            "frame_b64": frame_b64,
+            "timestamp": now,
+            "frame_hw": [H, W],
+            "unknown_captures": qualifying,
+        }
 
     def reset(self) -> None:
         """Reset all tracking state."""
         self._identities.clear()
         self._active_ids.clear()
-        self._current_faces.clear()
-        self._uploaded_unknown_ids.clear()
         if self._tracker is not None:
             self._tracker = self._init_tracker(
                 self._track_buffer, det_conf=self._det_conf

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -57,6 +57,8 @@ class _TrackIdentity:
     last_recog_time: float = 0.0
     frames_seen: int = 0
     recog_attempts: int = 0
+    # Unknown duration tracking (0.0 = not unknown)
+    unknown_since: float = 0.0
 
 
 class FaceTracker:
@@ -120,8 +122,20 @@ class FaceTracker:
         # Track IDs seen this frame (for cleanup)
         self._active_ids: set = set()
 
-        # Current frame faces (for status queries)
+        # Current frame faces sorted by area (for /who)
         self._current_faces: list = []
+
+        # Unknown capture: track_ids already captured (no repeat upload)
+        self._uploaded_unknown_ids: set = set()
+
+        # Frame dimensions (set on first update)
+        self._frame_area: int = 0
+
+        # Min bbox area ratio to qualify for unknown capture (0.3%)
+        self._unknown_area_ratio: float = 0.003
+
+        # Seconds an unknown must persist before capture
+        self._unknown_capture_delay: float = 5.0
 
     @staticmethod
     def _init_tracker(track_buffer: int, det_conf: float = 0.5):
@@ -218,9 +232,15 @@ class FaceTracker:
             ident = self._identities[track_id]
             ident.frames_seen += 1
 
+            # Track how long this face has been unknown
+            if ident.status == "identified":
+                ident.unknown_since = 0.0  # reset when identified
+            elif ident.unknown_since == 0.0:
+                ident.unknown_since = now  # start timing
+
             # Re-identify: if "unknown" or low-confidence "identified" and enough
             # time has passed, reset voting state so recognition retries.
-            # Handles the "walking closer" scenario where face gets clearer over time.
+            # High-confidence identified tracks are NOT re-verified.
             if (
                 self.re_identify_interval > 0
                 and (now - ident.last_recog_time) >= self.re_identify_interval
@@ -287,6 +307,9 @@ class FaceTracker:
         # Cleanup stale tracks
         self._cleanup_stale()
 
+        # Update frame area for unknown capture threshold
+        self._frame_area = H * W
+
         # Build faces sorted by bbox area (largest = closest first)
         faces = []
         for r in results:
@@ -299,6 +322,7 @@ class FaceTracker:
                     "name": name,
                     "bbox": r.bbox,
                     "area": area,
+                    "track_id": r.track_id,
                 }
             )
         self._current_faces = sorted(faces, key=lambda f: f["area"], reverse=True)
@@ -512,6 +536,7 @@ class FaceTracker:
             ident.status = "identified"
             ident.name = best_name
             ident.sim = avg_sim
+            ident.unknown_since = 0.0  # no longer unknown
             log.info(
                 f"Track {ident.track_id}: confirmed '{best_name}' "
                 f"(votes={best_count}/{total_votes}, sim={avg_sim:.3f})"
@@ -553,12 +578,69 @@ class FaceTracker:
             Each dict has 'name' (str), 'bbox' (tuple), 'area' (int).
             Empty list if no faces in current frame.
         """
-        return self._current_faces
+        return [
+            {"name": f["name"], "bbox": f["bbox"], "area": f["area"]}
+            for f in self._current_faces
+        ]
+
+    def get_capturable_unknown(self) -> Optional[dict]:
+        """Get an unknown face eligible for capture/upload.
+
+        Conditions:
+        - Status is not "identified" (unknown/new/identifying)
+        - Unknown for >= _unknown_capture_delay seconds (default 5s)
+        - Bbox area >= _unknown_area_ratio of frame area (default 0.3%)
+        - Not already captured (track_id not in _uploaded_unknown_ids)
+
+        Returns
+        -------
+        dict or None
+            {'track_id': int, 'bbox': tuple, 'area': int, 'timestamp': float}
+            or None if no eligible unknown.
+        """
+        if self._frame_area == 0:
+            return None
+
+        now = time.time()
+        min_area = self._frame_area * self._unknown_area_ratio
+
+        for face in self._current_faces:
+            if face["name"] != "unknown":
+                continue
+            if face["area"] < min_area:
+                continue
+
+            tid = face["track_id"]
+            ident = self._identities.get(tid)
+            if ident is None:
+                continue
+            if tid in self._uploaded_unknown_ids:
+                continue
+            if ident.unknown_since == 0.0:
+                continue
+            if (now - ident.unknown_since) < self._unknown_capture_delay:
+                continue
+
+            return {
+                "track_id": tid,
+                "bbox": face["bbox"],
+                "area": face["area"],
+                "timestamp": now,
+            }
+
+        return None
+
+    def mark_captured(self, track_id: int) -> None:
+        """Mark a track_id as captured so it won't be captured again."""
+        self._uploaded_unknown_ids.add(track_id)
+        log.info(f"Track {track_id}: marked as captured for upload")
 
     def reset(self) -> None:
         """Reset all tracking state."""
         self._identities.clear()
         self._active_ids.clear()
+        self._current_faces.clear()
+        self._uploaded_unknown_ids.clear()
         if self._tracker is not None:
             self._tracker = self._init_tracker(
                 self._track_buffer, det_conf=self._det_conf

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -301,6 +301,7 @@ class FaceTracker:
                     "name": name,
                     "bbox": r.bbox,
                     "area": area,
+                    "track_id": r.track_id,
                 }
             )
         self._current_faces = sorted(faces, key=lambda f: f["area"], reverse=True)
@@ -561,7 +562,7 @@ class FaceTracker:
         Returns
         -------
         list of dict
-            Each dict has 'name' (str), 'bbox' (tuple), 'area' (int).
+            Each dict has 'name', 'bbox', 'area', 'track_id'.
             Empty list if no faces in current frame.
         """
         return self._current_faces
@@ -601,6 +602,7 @@ class FaceTracker:
         """Reset all tracking state."""
         self._identities.clear()
         self._active_ids.clear()
+        self._current_faces.clear()
         if self._tracker is not None:
             self._tracker = self._init_tracker(
                 self._track_buffer, det_conf=self._det_conf

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -155,20 +155,12 @@ class HttpAPI:
                 if self.face_tracker is not None:
                     result["faces"] = self.face_tracker.get_faces()
 
-                    # Check for capturable unknown face
-                    capture = self.face_tracker.get_capturable_unknown()
-                    if capture is not None:
-                        with self.frame_lock:
-                            frm = (
-                                self.frame_state.frame_bgr.copy()
-                                if self.frame_state.frame_bgr is not None
-                                else None
-                            )
-                        if frm is not None:
-                            _, buf = cv2.imencode(".jpg", frm)
-                            capture["frame_b64"] = base64.b64encode(buf).decode("ascii")
-                            result["unknown_capture"] = capture
-                            self.face_tracker.mark_captured(capture["track_id"])
+                    # Drain pending unknown captures (queued by main loop)
+                    with self.frame_lock:
+                        captures = list(self.frame_state.pending_captures)
+                        self.frame_state.pending_captures.clear()
+                    if captures:
+                        result["unknown_captures"] = captures
 
                 return result
 

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -151,8 +151,25 @@ class HttpAPI:
                     else self.who.lookback_sec
                 )
                 result = self.who.snapshot(sec)
+
                 if self.face_tracker is not None:
                     result["faces"] = self.face_tracker.get_faces()
+
+                    # Check for capturable unknown face
+                    capture = self.face_tracker.get_capturable_unknown()
+                    if capture is not None:
+                        with self.frame_lock:
+                            frm = (
+                                self.frame_state.frame_bgr.copy()
+                                if self.frame_state.frame_bgr is not None
+                                else None
+                            )
+                        if frm is not None:
+                            _, buf = cv2.imencode(".jpg", frm)
+                            capture["frame_b64"] = base64.b64encode(buf).decode("ascii")
+                            result["unknown_capture"] = capture
+                            self.face_tracker.mark_captured(capture["track_id"])
+
                 return result
 
             if path == "/config":

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -152,15 +152,32 @@ class HttpAPI:
                 )
                 result = self.who.snapshot(sec)
 
-                if self.face_tracker is not None:
-                    result["faces"] = self.face_tracker.get_faces()
+                # Read frame + faces + unknowns under one lock (consistent snapshot)
+                with self.frame_lock:
+                    frm = (
+                        self.frame_state.frame_bgr.copy()
+                        if self.frame_state.frame_bgr is not None
+                        else None
+                    )
+                    faces = self.frame_state.current_faces
+                    unknowns = self.frame_state.current_unknowns
 
-                    # Drain pending unknown captures (queued by main loop)
-                    with self.frame_lock:
-                        captures = list(self.frame_state.pending_captures)
-                        self.frame_state.pending_captures.clear()
-                    if captures:
-                        result["unknown_captures"] = captures
+                if self.face_tracker is not None:
+                    result["faces"] = faces
+                    if unknowns:
+                        result["unknown_captures"] = unknowns
+
+                if frm is not None:
+                    _, buf = cv2.imencode(".jpg", frm, [cv2.IMWRITE_JPEG_QUALITY, 80])
+                    result["frame_b64"] = base64.b64encode(buf.tobytes()).decode(
+                        "ascii"
+                    )
+                    result["frame_hw"] = list(frm.shape[:2])
+                    result["frame_ts"] = time.time()
+                else:
+                    result["frame_b64"] = None
+                    result["frame_hw"] = None
+                    result["frame_ts"] = None
 
                 return result
 

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -120,6 +120,7 @@ import os
 import signal
 import threading
 import time
+from collections import deque
 from queue import Empty, Queue
 from typing import Any, Dict, List, Optional
 
@@ -182,6 +183,7 @@ class _FrameState:
         self.frame_bgr: Optional[np.ndarray] = None
         self.dets: Optional[np.ndarray] = None
         self.kpss: Optional[np.ndarray] = None
+        self.pending_captures: deque = deque(maxlen=50)
 
 
 def get_platform_prefix() -> str:
@@ -782,6 +784,12 @@ def main() -> None:
 
                 # Always call update so BoTSORT ages out lost tracks on empty frames
                 track_results = face_tracker.update(frame, dets, kpss)
+
+                # Check for capturable unknowns → queue for /who
+                capture = face_tracker.get_unknown_captures(frame, track_results)
+                if capture is not None:
+                    with frame_lock:
+                        frame_state.pending_captures.append(capture)
 
                 if dets is not None and dets.shape[0] > 0:
                     # Map track results back to detection indices (exclusive matching)

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -120,7 +120,6 @@ import os
 import signal
 import threading
 import time
-from collections import deque
 from queue import Empty, Queue
 from typing import Any, Dict, List, Optional
 
@@ -183,7 +182,8 @@ class _FrameState:
         self.frame_bgr: Optional[np.ndarray] = None
         self.dets: Optional[np.ndarray] = None
         self.kpss: Optional[np.ndarray] = None
-        self.pending_captures: deque = deque(maxlen=50)
+        self.current_faces: list = []
+        self.current_unknowns: list = []
 
 
 def get_platform_prefix() -> str:
@@ -785,11 +785,10 @@ def main() -> None:
                 # Always call update so BoTSORT ages out lost tracks on empty frames
                 track_results = face_tracker.update(frame, dets, kpss)
 
-                # Check for capturable unknowns → queue for /who
-                capture = face_tracker.get_unknown_captures(frame, track_results)
-                if capture is not None:
-                    with frame_lock:
-                        frame_state.pending_captures.append(capture)
+                # Snapshot faces + unknowns (consistent with frame_bgr saved above)
+                with frame_lock:
+                    frame_state.current_faces = face_tracker.get_faces()
+                    frame_state.current_unknowns = face_tracker.get_unknowns()
 
                 if dets is not None and dets.shape[0] > 0:
                     # Map track results back to detection indices (exclusive matching)


### PR DESCRIPTION
This pull request adds a mechanism to detect and capture frames containing unknown faces that persist for a configurable duration, making them available via the `/who` API endpoint. The implementation tracks how long each face remains unknown, ensures each unknown is captured only once, and encodes the relevant frame for later retrieval. The main themes are the addition of unknown face capture logic, state tracking enhancements, and integration with the HTTP API.

**Unknown face capture functionality:**

* Added the `get_unknown_captures` method to `FaceTracker`, which identifies unknown face tracks persisting beyond a threshold, encodes the frame as base64 JPEG, and returns metadata for each qualifying unknown face. Each track is captured only once.
* In the main processing loop (`run.py`), invoked `get_unknown_captures` after each frame, appending results to a new `pending_captures` queue in `frame_state` for later retrieval. [[1]](diffhunk://#diff-57b0f05afd2abea1222003feb649e9e6d0f909d1fb44368ee55ebe4bc4ab8933R788-R793) [[2]](diffhunk://#diff-57b0f05afd2abea1222003feb649e9e6d0f909d1fb44368ee55ebe4bc4ab8933R186)

**State tracking improvements:**

* Extended the `_TrackIdentity` class to track when a face first became unknown (`unknown_since`) and whether it has already been captured (`capture_count`).
* Updated `_finalize_identity` in `FaceTracker` to set or reset `unknown_since` appropriately when a track becomes or ceases to be unknown. [[1]](diffhunk://#diff-310345637e38bfad229bb9f6d5298838472a1aa8f1758cfe33edaa1884f860e8R492-R507) [[2]](diffhunk://#diff-310345637e38bfad229bb9f6d5298838472a1aa8f1758cfe33edaa1884f860e8R525-R534)

**API integration:**

* Modified the `/who` API handler in `http_api.py` to drain and return any pending unknown captures alongside face data, ensuring that captures are delivered to the client only once.

**Dependency and import updates:**

* Added necessary imports for `base64` and `deque` to support frame encoding and the pending captures queue. [[1]](diffhunk://#diff-310345637e38bfad229bb9f6d5298838472a1aa8f1758cfe33edaa1884f860e8R19) [[2]](diffhunk://#diff-57b0f05afd2abea1222003feb649e9e6d0f909d1fb44368ee55ebe4bc4ab8933R123)