### PR TITLE
Use persistent HTTP clients for TTS

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -502,6 +502,34 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -538,6 +566,7 @@ files = [
 [package.dependencies]
 anyio = "*"
 certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
 
@@ -547,6 +576,18 @@ cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "identify"
@@ -2267,4 +2308,4 @@ realsense = ["pyrealsense2", "pyrealsense2-macosx"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "02be3a6cfdf8321acf772dbf22f60525905aa276f0e93be513a57135de53f87a"
+content-hash = "f7f03fd0e8017cfcaf3281eb5ea07ecb07df4c799e0f64c402cb59f5adc95ea8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ openai= "1.60.1"
 filelock = "3.20.3"
 prometheus-client = "0.25.0"
 urllib3="2.7.0"
+httpx = {extras = ["http2"], version = "^0.28.1"}
 
 
 [tool.poetry.extras]

--- a/src/om1_speech/audio/audio_output_live_stream.py
+++ b/src/om1_speech/audio/audio_output_live_stream.py
@@ -8,6 +8,7 @@ import time
 from queue import Queue
 from typing import Any, Callable, Dict, Optional
 
+import httpx
 import openai
 import zenoh
 
@@ -70,6 +71,15 @@ class AudioOutputLiveStream:
         self.openai_client = openai.OpenAI(
             base_url=self._url,
             api_key=self._api_key or "no-need-api-key",
+            http_client=httpx.Client(
+                http2=True,
+                limits=httpx.Limits(
+                    max_keepalive_connections=10,
+                    max_connections=20,
+                    keepalive_expiry=300.0,
+                ),
+                timeout=httpx.Timeout(60.0, connect=5.0),
+            ),
         )
 
         # Callback for TTS state

--- a/src/om1_speech/audio/audio_output_stream.py
+++ b/src/om1_speech/audio/audio_output_stream.py
@@ -58,6 +58,9 @@ class AudioOutputStream:
         # Callback for TTS state
         self._tts_state_callback = tts_state_callback
 
+        # HTTP session
+        self._session = requests.Session()
+
         # Zenoh
         self.topic = "robot/status/audio"
         self.session = None
@@ -166,7 +169,7 @@ class AudioOutputStream:
             try:
                 start_time = time.time()
                 tts_request = self._pending_requests.get()
-                response = requests.post(
+                response = self._session.post(
                     self._url,
                     data=json.dumps(tts_request),
                     headers=self._headers,
@@ -380,6 +383,9 @@ class AudioOutputStream:
         Stop the audio output stream and cleanup resources.
         """
         self.running = False
+
+        if self._session:
+            self._session.close()
 
         if self.session:
             self.session.close()

--- a/tests/om1_speech/audio/test_audio_output_live_stream.py
+++ b/tests/om1_speech/audio/test_audio_output_live_stream.py
@@ -3,7 +3,7 @@ import subprocess
 import threading
 import time
 from queue import Queue
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 
@@ -518,6 +518,7 @@ def test_openai_client_creation(mock_openai, mock_zenoh):
     mock_openai.assert_called_once_with(
         base_url="http://test-server/v1",
         api_key="test-key",
+        http_client=ANY,
     )
 
     stream.stop()
@@ -534,6 +535,7 @@ def test_openai_client_no_api_key(mock_openai, mock_zenoh):
     mock_openai.assert_called_once_with(
         base_url="http://test-server/v1",
         api_key="no-need-api-key",
+        http_client=ANY,
     )
 
     stream.stop()

--- a/tests/om1_speech/audio/test_audio_output_stream.py
+++ b/tests/om1_speech/audio/test_audio_output_stream.py
@@ -48,7 +48,7 @@ def mock_ffplay():
 
 @pytest.fixture
 def mock_requests():
-    with patch("requests.post") as mock:
+    with patch("requests.Session.post") as mock:
         # Setup mock response
         mock_response = Mock()
         mock_response.status_code = 200


### PR DESCRIPTION
Add httpx as a dependency and configure persistent HTTP clients for text-to-speech requests. The OpenAI client is now initialized with a custom httpx.Client (HTTP/2, connection limits and timeouts) in the live-stream output. The non-live output stream now reuses a requests.Session for POST requests and closes it on shutdown to improve connection reuse and performance. Also import httpx where needed and adjust resource cleanup accordingly.