### PR TITLE
Add httpx helper and use shared client

### DIFF
--- a/src/om1_speech/audio/audio_output_live_stream.py
+++ b/src/om1_speech/audio/audio_output_live_stream.py
@@ -8,11 +8,11 @@ import time
 from queue import Queue
 from typing import Any, Callable, Dict, Optional
 
-import httpx
 import openai
 import zenoh
 
 from om1_speech.prometheus import om1_tts_latency, om1_tts_latency_last
+from om1_utils import get_httpx_client
 from zenoh_msgs import AudioStatus, String, open_zenoh_session, prepare_header
 
 root_package_name = __name__.split(".")[0] if "." in __name__ else __name__
@@ -71,15 +71,7 @@ class AudioOutputLiveStream:
         self.openai_client = openai.OpenAI(
             base_url=self._url,
             api_key=self._api_key or "no-need-api-key",
-            http_client=httpx.Client(
-                http2=True,
-                limits=httpx.Limits(
-                    max_keepalive_connections=10,
-                    max_connections=20,
-                    keepalive_expiry=300.0,
-                ),
-                timeout=httpx.Timeout(60.0, connect=5.0),
-            ),
+            http_client=get_httpx_client(),
         )
 
         # Callback for TTS state

--- a/src/om1_utils/__init__.py
+++ b/src/om1_utils/__init__.py
@@ -1,4 +1,5 @@
 from . import http, logging, ws
+from .httpx import get_httpx_client, get_httpx_event_hooks
 from .logging import LoggingConfig, get_logging_config, setup_logging
 from .singleton import singleton
 
@@ -10,4 +11,6 @@ __all__ = [
     "setup_logging",
     "get_logging_config",
     "LoggingConfig",
+    "get_httpx_client",
+    "get_httpx_event_hooks",
 ]

--- a/src/om1_utils/httpx/__init__.py
+++ b/src/om1_utils/httpx/__init__.py
@@ -1,0 +1,101 @@
+import logging
+import time
+
+import httpx
+
+
+def get_httpx_event_hooks() -> dict[str, list]:
+    """
+    Return a dictionary of event hooks for logging HTTP requests and responses.
+
+    Returns
+    -------
+    dict[str, list]
+        A dictionary containing lists of event hook functions for 'request' and 'response' events.
+    """
+
+    def log_request(request: httpx.Request):
+        """
+        Log details of the outgoing HTTP request.
+
+        Parameters
+        ----------
+        request : httpx.Request
+            The HTTP request object to log.
+        """
+        request.extensions["start_time"] = time.perf_counter()
+
+    def log_response(response: httpx.Response):
+        """
+        Log details of the incoming HTTP response, including latency.
+
+        Parameters
+        ----------
+        response : httpx.Response
+            The HTTP response object to log.
+        """
+        start_time = response.request.extensions.get("start_time", 0)
+        elapsed = (time.perf_counter() - start_time) * 1000
+        http_version = response.http_version
+        proxy_parse_total_time = response.headers.get("x-proxy-parse-ms", "?")
+        upstream_total_time = response.headers.get("x-upstream-total-ms", "?")
+        upstream_ttfb_time = response.headers.get("x-upstream-ttfb-ms", "?")
+        proxy_total_time = response.headers.get("x-proxy-total-ms", "?")
+        logging.info(
+            f"HTTP {response.request.method} {response.request.url} - "
+            f"Status: {response.status_code}, "
+            f"HTTP Version: {http_version}, "
+            f"Elapsed: {elapsed:.2f} ms, "
+            f"Proxy Parse Time: {proxy_parse_total_time} ms, "
+            f"Upstream Total Time: {upstream_total_time} ms, "
+            f"Upstream TTFB: {upstream_ttfb_time} ms, "
+            f"Proxy Total Time: {proxy_total_time} ms"
+        )
+
+    return {
+        "request": [log_request],
+        "response": [log_response],
+    }
+
+
+def get_httpx_client(
+    http2: bool = True,
+    max_keepalive_connections: int = 20,
+    max_connections: int = 100,
+    keepalive_expiry: float = 300.0,
+    timeout: float = 60.0,
+    connect_timeout: float = 5.0,
+) -> httpx.Client:
+    """
+    Create and return a configured Client for HTTP requests.
+
+    Parameters
+    ----------
+    http2 : bool
+        Whether to enable HTTP/2 support.
+    max_keepalive_connections : int
+        Maximum number of keep-alive connections to maintain.
+    max_connections : int
+        Maximum number of concurrent connections allowed.
+    keepalive_expiry : float
+        Time in seconds before idle keep-alive connections are closed.
+    timeout : float
+        Total timeout for requests in seconds.
+    connect_timeout : float
+        Timeout for establishing a connection in seconds.
+
+    Returns
+    -------
+    httpx.Client
+        A configured Client instance ready for making HTTP requests.
+    """
+    return httpx.Client(
+        http2=http2,
+        limits=httpx.Limits(
+            max_keepalive_connections=max_keepalive_connections,
+            max_connections=max_connections,
+            keepalive_expiry=keepalive_expiry,
+        ),
+        timeout=httpx.Timeout(timeout, connect=connect_timeout),
+        event_hooks=get_httpx_event_hooks(),
+    )


### PR DESCRIPTION
Introduce a new om1_utils.httpx module that provides get_httpx_client() and get_httpx_event_hooks() to centralize HTTPX configuration and request/response logging. Export these helpers from om1_utils.__init__.py. Replace an inline httpx.Client in AudioOutputLiveStream with get_httpx_client() to reuse consistent timeouts, connection limits, HTTP/2 support, and event hooks that log latency and proxy/upstream timing headers.