### PR TITLE
Warn on large WebSocket message queue

### DIFF
--- a/src/om1_utils/ws/client.py
+++ b/src/om1_utils/ws/client.py
@@ -141,6 +141,12 @@ class Client:
         if self.connected:
             self.message_queue.put(message)
 
+        qsize = self.message_queue.qsize()
+        if qsize > 20:
+            logger.warning(
+                f"Message queue size is {qsize}, which may indicate a backlog"
+            )
+
     def _run_client(self):
         """
         Internal method to manage the WebSocket client lifecycle.


### PR DESCRIPTION
Add a queue size check to the WebSocket Client that logs a warning when message_queue.qsize() exceeds 20. This helps surface potential backlogs or latency issues by notifying when the client-side message queue is growing unexpectedly.