### PR TITLE
replace base64 with raw data

### DIFF
--- a/src/om1_speech/audio/audio_input_stream.py
+++ b/src/om1_speech/audio/audio_input_stream.py
@@ -8,7 +8,7 @@ import queue
 import struct
 import threading
 import time
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, Callable, Generator, List, Optional, Tuple, Union
 
 import pyaudio
 import zenoh

--- a/src/om1_speech/audio/audio_input_stream.py
+++ b/src/om1_speech/audio/audio_input_stream.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 import queue
+import struct
 import threading
 import time
 from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
@@ -416,7 +417,7 @@ class AudioInputStream:
                 self._rate = rate
                 self._language_code = language_code
 
-    def generator(self) -> Generator[Dict[str, Union[bytes, int]], None, None]:
+    def generator(self) -> Generator[bytes, None, None]:
         """
         Generates a stream of audio data chunk.
 
@@ -437,17 +438,17 @@ class AudioInputStream:
                 if self._is_tts_active:
                     continue
 
-            data = [chunk]
-
-            response = {
-                "audio": base64.b64encode(b"".join(data)).decode("utf-8"),
+            config = {
                 "rate": self._rate,
                 "language_code": self._language_code,
                 "alternative_language_codes": self._alternative_language_codes,
-                "timestamp": int(time.time()),
             }
+
+            config["timestamp"] = int(time.time() * 1000)
+            header = json.dumps(config).encode("utf-8")
+            response = struct.pack(">I", len(header)) + header + chunk
             for audio_callback in self._audio_data_callbacks:
-                audio_callback(json.dumps(response))
+                audio_callback(response)
 
             yield response
 

--- a/src/om1_speech/audio/audio_rtsp_input_stream.py
+++ b/src/om1_speech/audio/audio_rtsp_input_stream.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 import multiprocessing as mp
+import struct
 import threading
 import time
 from queue import Empty, Full
@@ -414,7 +415,7 @@ class AudioRTSPInputStream:
                 self._rate = rate
                 self._language_code = language_code
 
-    def generator(self) -> Generator[Dict[str, Union[bytes, int]], None, None]:
+    def generator(self) -> Generator[bytes, None, None]:
         """
         Generates a stream of audio data chunk.
 
@@ -435,17 +436,17 @@ class AudioRTSPInputStream:
                 if self._is_tts_active:
                     continue
 
-            data = [chunk]
-
-            response = {
-                "audio": base64.b64encode(b"".join(data)).decode("utf-8"),
+            config = {
                 "rate": self._rate,
                 "language_code": self._language_code,
                 "alternative_language_codes": self._alternative_language_codes,
-                "timestamp": int(time.time()),
             }
+
+            config["timestamp"] = int(time.time() * 1000)
+            header = json.dumps(config).encode("utf-8")
+            response = struct.pack(">I", len(header)) + header + chunk
             for audio_callback in self._audio_data_callbacks:
-                audio_callback(json.dumps(response))
+                audio_callback(response)
 
             yield response
 

--- a/src/om1_speech/audio/audio_rtsp_input_stream.py
+++ b/src/om1_speech/audio/audio_rtsp_input_stream.py
@@ -6,7 +6,7 @@ import struct
 import threading
 import time
 from queue import Empty, Full
-from typing import Callable, Dict, Generator, List, Optional, Union
+from typing import Callable, Generator, List, Optional, Union
 
 import av
 import numpy as np

--- a/tests/om1_speech/audio/test_audio_input_stream.py
+++ b/tests/om1_speech/audio/test_audio_input_stream.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import queue
+import struct
 import threading
 from unittest.mock import MagicMock, Mock, patch
 
@@ -146,7 +147,7 @@ def test_generator(audio_stream):
     audio_stream._buff.put(None)
 
     assert len(collected_chunks) > 0
-    assert all(isinstance(data, dict) for data in collected_chunks)
+    assert all(isinstance(data, bytes) for data in collected_chunks)
 
 
 def test_stop(audio_stream, mock_pyaudio):
@@ -182,16 +183,17 @@ def test_audio_callback(mock_pyaudio):
         # Process one chunk through generator
         next(stream.generator())
 
-    # Verify callback was called with correct data
-    assert callback_data == json.dumps(
-        {
-            "audio": base64.b64encode(test_data).decode("utf-8"),
-            "rate": 16000,
-            "language_code": "en-US",
-            "alternative_language_codes": [],
-            "timestamp": fixed_time,
-        }
-    )
+    # Verify callback was called with binary header format
+    assert isinstance(callback_data, bytes)
+    header_len = struct.unpack(">I", callback_data[:4])[0]
+    header = json.loads(callback_data[4 : 4 + header_len])
+    audio = callback_data[4 + header_len :]
+
+    assert header["rate"] == 16000
+    assert header["language_code"] == "en-US"
+    assert header["alternative_language_codes"] == []
+    assert header["timestamp"] == int(fixed_time * 1000)
+    assert audio == test_data
 
     stream.stop()
 
@@ -258,10 +260,15 @@ def test_generator_with_alternative_languages(mock_pyaudio):
 
     generated = next(stream.generator())
 
-    assert generated["language_code"] == "en-GB"
-    assert generated["alternative_language_codes"] == alt_langs
-    assert generated["audio"] == base64.b64encode(test_data).decode("utf-8")
-    assert generated["rate"] == 16000
+    assert isinstance(generated, bytes)
+    header_len = struct.unpack(">I", generated[:4])[0]
+    header = json.loads(generated[4 : 4 + header_len])
+    audio = generated[4 + header_len :]
+
+    assert header["language_code"] == "en-GB"
+    assert header["alternative_language_codes"] == alt_langs
+    assert header["rate"] == 16000
+    assert audio == test_data
 
     stream.stop()
 
@@ -318,15 +325,15 @@ def test_audio_callback_with_alternative_languages(mock_pyaudio):
 
         next(stream.generator())
 
-    expected_data = json.dumps(
-        {
-            "audio": base64.b64encode(test_data).decode("utf-8"),
-            "rate": 16000,
-            "language_code": "es-MX",
-            "alternative_language_codes": alt_langs,
-            "timestamp": fixed_time,
-        }
-    )
-    assert callback_data == expected_data
+    assert isinstance(callback_data, bytes)
+    header_len = struct.unpack(">I", callback_data[:4])[0]
+    header = json.loads(callback_data[4 : 4 + header_len])
+    audio = callback_data[4 + header_len :]
+
+    assert header["rate"] == 16000
+    assert header["language_code"] == "es-MX"
+    assert header["alternative_language_codes"] == alt_langs
+    assert header["timestamp"] == int(fixed_time * 1000)
+    assert audio == test_data
 
     stream.stop()


### PR DESCRIPTION
This pull request refactors the audio streaming code in both `audio_input_stream.py` and `audio_rtsp_input_stream.py` to improve how audio data is packaged and transmitted. The main change is switching from a JSON-based response containing base64-encoded audio to a binary format that prepends a JSON header to the raw audio chunk. This should improve efficiency and simplify downstream processing.

**Audio streaming protocol changes:**

* The `generator` method in both `audio_input_stream.py` and `audio_rtsp_input_stream.py` now yields raw `bytes` instead of a dictionary with base64-encoded audio. The new format consists of a 4-byte length-prefixed JSON header followed by the raw audio chunk. (`[[1]](diffhunk://#diff-74140ed30247fd9aaedddedae151eac279bb8026a26f6021b171d09fdbc3bd99L419-R420)`, `[[2]](diffhunk://#diff-6495332b6ea94450241e9a14106cad03cbda46ebc4e10ea720ba8217a29259a8L417-R418)`)
* The JSON header now includes a millisecond-precision timestamp (`timestamp`), and is serialized and prefixed to the audio chunk using `struct.pack`. (`[[1]](diffhunk://#diff-74140ed30247fd9aaedddedae151eac279bb8026a26f6021b171d09fdbc3bd99L440-R451)`, `[[2]](diffhunk://#diff-6495332b6ea94450241e9a14106cad03cbda46ebc4e10ea720ba8217a29259a8L438-R449)`)

**Code and interface updates:**

* Updated import statements to include `struct` for binary packing. (`[[1]](diffhunk://#diff-74140ed30247fd9aaedddedae151eac279bb8026a26f6021b171d09fdbc3bd99R8)`, `[[2]](diffhunk://#diff-6495332b6ea94450241e9a14106cad03cbda46ebc4e10ea720ba8217a29259a8R5)`)
* Audio data callbacks now receive the new binary format instead of a JSON string. (`[[1]](diffhunk://#diff-74140ed30247fd9aaedddedae151eac279bb8026a26f6021b171d09fdbc3bd99L440-R451)`, `[[2]](diffhunk://#diff-6495332b6ea94450241e9a14106cad03cbda46ebc4e10ea720ba8217a29259a8L438-R449)`)

These changes make the audio streaming more efficient and consistent across both input stream modules.