### PR TITLE
Add autoenroll and UUID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 *.engine
 *.onnx
 venv/
+.venv/

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/__init__.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "scrfd",
     "gallery",
     "io",
+    "selfie_logic",
     "http_api",
     "who_tracker",
     "yolo_pose",

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/auto_enroller.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/auto_enroller.py
@@ -48,6 +48,8 @@ from typing import Callable, Deque, Dict, List, Optional, Tuple
 
 import numpy as np
 
+from . import selfie_logic as sl
+
 log = logging.getLogger(__name__)
 
 
@@ -197,6 +199,8 @@ class AutoEnroller:
         merge_thr: float = 0.50,
         source_tag: str = "auto_enroll",
         on_committed: Optional[Callable[[str, int, int], None]] = None,
+        min_conf: float = 0.0,
+        min_frontality: float = 0.0,
     ):
         self.gallery = gallery
         self.n_required = int(n_samples_required)
@@ -208,6 +212,10 @@ class AutoEnroller:
         self.merge_thr = float(merge_thr)
         self.source_tag = str(source_tag)
         self.on_committed = on_committed
+        # Dedicated auto-enroll quality gates, independent of the /selfie
+        # thresholds. 0.0 = gate disabled.
+        self.min_conf = float(min_conf)
+        self.min_frontality = float(min_frontality)
 
         # track_id → buffer
         self._buffers: Dict[int, _TrackBuffer] = {}
@@ -228,6 +236,8 @@ class AutoEnroller:
         embedding: np.ndarray,
         bbox: Tuple[int, int, int, int],
         tier: str,
+        kps: Optional[np.ndarray] = None,
+        conf: float = 1.0,
     ) -> Optional[str]:
         """Feed one frame's recognition result for one track.
 
@@ -269,6 +279,17 @@ class AutoEnroller:
         x1, y1, x2, y2 = bbox
         if min(x2 - x1, y2 - y1) < self.min_face_pixels:
             return None
+
+        # Dedicated auto-enroll quality gate (independent of /selfie): require
+        # a confident, frontal detection before buffering, so only clean
+        # frontal faces enter the gallery. Does NOT affect what the robot can
+        # SEE/track — the global DETECTION_CONFIDENCE stays low; this only
+        # gates enrollment. 0.0 thresholds = gate off.
+        if self.min_conf > 0.0 and conf < self.min_conf:
+            return None
+        if self.min_frontality > 0.0 and kps is not None:
+            if sl.frontality(kps) < self.min_frontality:
+                return None
 
         # Get or create buffer
         buf = self._buffers.get(track_id)

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/auto_enroller.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/auto_enroller.py
@@ -1,0 +1,635 @@
+"""
+Auto-enrollment: silently build a UUID for a face that keeps showing up unknown.
+
+How it works
+------------
+1. Per recognition pass, face_tracker hands us (track_id, aligned_crop,
+   embedding, sim_top1) for tracks that came back ``"uncertain"``. We do
+   no GPU work here — embedding is already computed upstream.
+
+2. For each track, we maintain a small buffer of recent samples (default
+   max_buffer=5). Samples must pass a per-frame quality bar (frontality,
+   sharpness, face size) — bad frames are dropped immediately.
+
+3. When a track's buffer hits ``n_samples_required`` AND the pairwise
+   cosine similarity between buffered samples is tight enough
+   (``min_pairwise_sim``, default 0.6) — meaning they all look like the
+   same person, not a flicker between two visitors — we commit a new
+   UUID with name="" (anonymous). The LLM can name it later via
+   ``/set_name``.
+
+4. Tracks that disappear (no more frames) get their buffer dropped after
+   ``stale_track_sec``. Tracks that get identified by face_tracker also
+   get dropped (no need to enroll them).
+
+Why this exists
+---------------
+Right now, enrollment requires the LLM to ask "what's your name?" and
+call /selfie. For drop-in visitors who never speak, we'd never enroll
+them. With auto-enroll, the gallery quietly grows; the LLM only has to
+*name* the identities, not create them. Naming is then a snappy O(1)
+metadata write instead of a multi-frame collection loop.
+
+Threading model
+---------------
+Same as gallery.py — all methods should be called from the main thread
+(via the recognition callback inside face_tracker.update). No internal
+locking. Maintains its own per-track buffer; doesn't touch shared state
+except by calling gallery methods.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Callable, Deque, Dict, List, Optional, Tuple
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+
+# Tier name from selfie_logic — duplicated here as a string constant so this
+# module doesn't import face_tracker / selfie_logic (cleaner dependency graph).
+_TIER_UNCERTAIN = "uncertain"
+
+
+# ---------------------------------------------------------------------------
+# Per-track buffer
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _TrackBuffer:
+    """Rolling buffer of recent samples for one unknown track.
+
+    We keep aligned crops AND their embeddings — embeddings for the
+    tightness/novelty checks, crops for the eventual commit to the gallery.
+
+    Timestamps
+    ----------
+    first_seen : first time we created a buffer for this track. Drives the
+        ``min_unknown_sec`` gate.
+    last_seen : most recent ``observe()`` call for this track (whether or
+        not the sample was buffered). Drives ``gc_stale`` — if no observe
+        has fired in ``stale_track_sec``, the track is gone and we drop
+        the buffer.
+
+    Note: there's no ``last_buffered`` because sample-spacing is controlled
+    by embedding-based novelty (not time). See AutoEnroller.observe() and
+    the ``novelty_thr`` parameter for the rationale.
+    """
+
+    track_id: int
+    crops: Deque[np.ndarray] = field(default_factory=deque)
+    embeddings: Deque[np.ndarray] = field(default_factory=deque)
+    first_seen: float = 0.0
+    last_seen: float = 0.0
+    # True after we've successfully enrolled this track — prevents double
+    # enrollment if more samples arrive before face_tracker picks up the new
+    # gallery centroid and starts identifying this track as "confident".
+    committed_uuid: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# AutoEnroller
+# ---------------------------------------------------------------------------
+
+
+class AutoEnroller:
+    """Watches unknown tracks and silently enrolls them when confident.
+
+    Parameters
+    ----------
+    gallery : UUIDGallery
+        Where new identities are created. Must be writable from the calling
+        thread (i.e. the main thread when this is wired via run_job_sync).
+    n_samples_required : int, default 3
+        How many quality samples must accumulate before we even consider
+        enrolling. Lower → faster enrollment, more risk of bad identities.
+    max_buffer : int, default 5
+        Maximum samples kept per track. When full, oldest is dropped. Should
+        be ≥ n_samples_required.
+    min_pairwise_sim : float, default 0.55
+        Required pairwise cosine similarity (worst pair) across the buffer
+        before enrollment. Filters out tracks that "flicker" between two
+        people (BoTSORT ID switch on similar-looking visitors). Conservative
+        starting value; tune up if you see misenrollments.
+    min_unknown_sec : float, default 1.5
+        Track must have been visible/unknown for at least this long before
+        enrollment fires. Keeps us from enrolling people who just walked
+        through the frame.
+    min_face_pixels : int, default 80
+        Minimum bbox short side. Below this, samples are skipped — they're
+        too small to be reliable.
+    capture_interval_sec : float, default 0.3
+        Minimum time between buffered samples for the same track. Prevents
+        the buffer from filling with near-duplicates from consecutive frames.
+    stale_track_sec : float, default 5.0
+        Drop a track's buffer if no observe() in this long. Saves memory on
+        tracks that walked off.
+    merge_thr : float, default 0.50
+        Before creating a NEW UUID, check whether the buffer's mean embedding
+        is close enough to any existing UUID's centroid. If max cosine sim
+        across the gallery >= ``merge_thr``, append the samples to that
+        existing UUID instead of creating a new one.
+
+        Why this exists: ``SIM_THR`` is the per-frame recognition floor —
+        below it, a face is labeled "unknown" even if it's a known person
+        in bad lighting (top1=0.52 but margin=0.20 → "uncertain" because
+        0.52 < SIM_THR=0.55, but actually it's clearly wendy). Without this
+        merge step, AutoEnroller would create a duplicate UUID for wendy
+        every time she walks into a different lighting condition.
+
+        The buffer mean is more reliable than any single frame's embedding
+        (averaging suppresses noise), so this check uses the WHOLE buffer's
+        centroid against the gallery — typically higher than the per-frame
+        top1, often crossing into the "definitely this known person" zone.
+
+        Set lower than SIM_THR. Setting to 0 disables the merge-on-commit
+        path (always creates new UUIDs, original behavior).
+    source_tag : str, default "auto_enroll"
+        ``source`` value to write into metadata.json for traceability.
+    on_committed : callable, optional
+        Optional callback ``on_committed(uuid, track_id, sample_count)``
+        fired immediately after a successful enrollment. Useful for the
+        main loop to refresh face_tracker's gallery snapshot.
+
+    Why no per-sample novelty/consistency check
+    -------------------------------------------
+    Earlier iterations had two embedding-based gates here:
+      - novelty (reject if sim_to_mean > 0.97): tried to avoid buffering
+        near-duplicate frames
+      - consistency (reject if sim_to_mean < 0.50): tried to catch
+        BoTSORT track-id swaps mid-buffer
+
+    Problem with novelty: a person standing naturally still produces
+    sim ≈ 0.95-0.99 between consecutive frames. Setting novelty_thr
+    permissively (0.97) starves the buffer in the still case; setting
+    it loosely (0.99) makes the gate near-meaningless. The "window"
+    (sim < novelty_thr AND sim > consistency_thr) often excludes
+    perfectly valid same-person frames.
+
+    Problem with consistency vs tightness: the per-sample consistency
+    check is mostly redundant with the at-commit tightness check
+    (``min_pairwise_sim``). Both reject "buffer contains samples of
+    multiple people".
+
+    Resolution: skip both per-sample checks. Accept all quality samples
+    into the buffer; rely on tightness at commit time. Within-pose
+    averaging from 3+ similar samples still yields a more robust
+    centroid than any single sample. Cross-pose diversity comes from
+    repeat encounters via the ``merge_thr`` path, not from one session.
+    """
+
+    def __init__(
+        self,
+        gallery,
+        *,
+        n_samples_required: int = 3,
+        max_buffer: int = 5,
+        min_pairwise_sim: float = 0.55,
+        min_unknown_sec: float = 1.0,
+        min_face_pixels: int = 30,
+        stale_track_sec: float = 5.0,
+        merge_thr: float = 0.50,
+        source_tag: str = "auto_enroll",
+        on_committed: Optional[Callable[[str, int, int], None]] = None,
+    ):
+        self.gallery = gallery
+        self.n_required = int(n_samples_required)
+        self.max_buffer = max(int(max_buffer), self.n_required)
+        self.min_pairwise_sim = float(min_pairwise_sim)
+        self.min_unknown_sec = float(min_unknown_sec)
+        self.min_face_pixels = int(min_face_pixels)
+        self.stale_track_sec = float(stale_track_sec)
+        self.merge_thr = float(merge_thr)
+        self.source_tag = str(source_tag)
+        self.on_committed = on_committed
+
+        # track_id → buffer
+        self._buffers: Dict[int, _TrackBuffer] = {}
+
+        # Stats (for /who debug)
+        self.enrolled_count = 0
+        self.merged_count = 0    # NEW: tracks merge-on-commit decisions
+        self.rejected_count = 0
+
+    # ------------------------------------------------------------------
+    # Main entry points
+    # ------------------------------------------------------------------
+
+    def observe(
+        self,
+        track_id: int,
+        aligned_crop: np.ndarray,
+        embedding: np.ndarray,
+        bbox: Tuple[int, int, int, int],
+        tier: str,
+    ) -> Optional[str]:
+        """Feed one frame's recognition result for one track.
+
+        Called from face_tracker._run_recognition_batch for EVERY track that
+        ran recognition this batch (not just unknown ones — passing
+        identified tracks lets us drop their buffers if they were previously
+        unknown).
+
+        Parameters
+        ----------
+        track_id : int
+            BoTSORT track id. Stable across frames for the same person.
+        aligned_crop : ndarray (112, 112, 3) BGR
+            Same warped crop that was fed to AdaFace. Reused for storage.
+        embedding : ndarray (512,) float32, L2-normalized
+            AdaFace output for ``aligned_crop``.
+        bbox : (x1, y1, x2, y2)
+            Face bbox in image coordinates. Used for the size gate.
+        tier : str
+            Recognition tier from selfie_logic.recognize_from_sims.
+            We only buffer samples when tier is "uncertain"; tracks that
+            became identified get their buffer cleared.
+
+        Returns
+        -------
+        Optional[str]
+            If this observation triggered an enrollment, returns the new
+            UUID. Otherwise None. Most calls return None.
+        """
+        now = time.time()
+
+        # Track became identified or tentative → drop any buffer, no enroll
+        if tier != _TIER_UNCERTAIN:
+            self._buffers.pop(track_id, None)
+            return None
+
+        # Quality / size gate happens FIRST — don't even create a buffer
+        # entry for samples that fail the bar. Avoids leaking empty entries.
+        x1, y1, x2, y2 = bbox
+        if min(x2 - x1, y2 - y1) < self.min_face_pixels:
+            return None
+
+        # Get or create buffer
+        buf = self._buffers.get(track_id)
+        if buf is None:
+            buf = _TrackBuffer(
+                track_id=track_id, first_seen=now, last_seen=now,
+            )
+            self._buffers[track_id] = buf
+
+        # Always mark the track as recently seen — keeps gc_stale honest
+        # even when the sample below gets rate-limited away.
+        buf.last_seen = now
+
+        # Already enrolled this track — wait for face_tracker to start
+        # identifying it as "confident". Don't enroll again.
+        if buf.committed_uuid is not None:
+            return None
+
+        # No per-sample novelty/consistency check. We accept every quality
+        # sample and rely on min_pairwise_sim (the tightness check at commit
+        # time) to catch BoTSORT track-id swaps. See the class docstring
+        # for the rationale.
+
+        # Buffer this sample (drop oldest if at capacity)
+        buf.crops.append(aligned_crop.copy())
+        buf.embeddings.append(embedding.copy())
+        if len(buf.crops) > self.max_buffer:
+            buf.crops.popleft()
+            buf.embeddings.popleft()
+
+        # Eligibility checks
+        if len(buf.embeddings) < self.n_required:
+            return None
+        if (now - buf.first_seen) < self.min_unknown_sec:
+            return None
+
+        # Pairwise tightness check
+        worst = self._min_pairwise_sim(list(buf.embeddings))
+        if worst < self.min_pairwise_sim:
+            log.debug(
+                "auto-enroll track=%d skipped: pairwise=%.3f < %.3f",
+                track_id, worst, self.min_pairwise_sim,
+            )
+            self.rejected_count += 1
+            # Don't drop the buffer — maybe later samples improve cohesion.
+            # But cap how much we wait by trimming oldest if we exceeded buffer.
+            return None
+
+        # All gates passed → commit
+        uuid = self._commit(buf)
+        return uuid
+
+    def force_commit(self, track_id: int, name: str = "") -> Optional[str]:
+        """Commit a track's buffer immediately, even if gates aren't satisfied.
+
+        Used by /selfie when the LLM has just learned the person's name but
+        auto-enroll hasn't fired yet for this track. The selfie collection
+        loop itself produces fresh samples; this method drains whatever
+        auto-enroll has already buffered.
+
+        Returns the UUID, or None if the track has no buffer or only 0
+        samples (nothing to commit).
+        """
+        buf = self._buffers.get(track_id)
+        if buf is None or not buf.crops:
+            return None
+        if buf.committed_uuid is not None:
+            # Already committed — caller can use that UUID
+            return buf.committed_uuid
+        uuid = self._commit(buf, name=name, forced=True)
+        return uuid
+
+    def drop_track(self, track_id: int) -> None:
+        """Explicitly drop a track's buffer (e.g. when track was identified
+        as a known person by a different path)."""
+        self._buffers.pop(track_id, None)
+
+    def gc_stale(self) -> int:
+        """Remove buffers for tracks that haven't been observed recently.
+
+        Returns the number of buffers dropped. Called once per frame (cheap)
+        from the main loop, OR every few seconds from a slower timer.
+        """
+        now = time.time()
+        cutoff = now - self.stale_track_sec
+        stale = [tid for tid, buf in self._buffers.items() if buf.last_seen < cutoff]
+        for tid in stale:
+            self._buffers.pop(tid, None)
+        return len(stale)
+
+    def try_commit_pending(self) -> List[str]:
+        """Scan all active buffers and commit any that pass all gates.
+
+        WHY THIS EXISTS
+        ---------------
+        AutoEnroller's commit logic in ``observe()`` is event-driven — it
+        only runs when face_tracker calls observe() with a new sample.
+        But after face_tracker finalizes a track as ``status="unknown"``,
+        it stops calling observe() until re-identify fires (≥1s later).
+
+        Without this method, a buffer that accumulated enough samples
+        BEFORE the track went "unknown" would just sit there waiting:
+          - sample_count gate: PASSED (≥ n_required)
+          - tightness gate:    PASSED (samples are consistent)
+          - time gate:         MAY pass during the dead zone
+
+        but no observe() is being called to trigger the gate check. So
+        the UUID creation gets delayed by up to re_identify_interval
+        seconds, even though every condition has been met.
+
+        This method, called periodically from the main loop, polls all
+        buffers and commits any that pass all gates RIGHT NOW. Solves
+        the "system knows it's a stranger but hasn't enrolled them yet"
+        latency.
+
+        Idempotent — already-committed buffers are skipped. Returns the
+        list of UUIDs created during this call (usually empty, sometimes
+        1+ if multiple unknown tracks ripened at once).
+
+        Cheap: typically iterates over a handful of buffers, each gate
+        check is O(1) or O(n²) on small embedding lists (n ≤ max_buffer).
+        Safe to call every frame, though every ~1s is enough.
+        """
+        if not self._buffers:
+            return []
+        now = time.time()
+        committed: List[str] = []
+        for track_id, buf in list(self._buffers.items()):
+            # Skip already-committed buffers
+            if buf.committed_uuid is not None:
+                continue
+            # Sample count gate
+            if len(buf.embeddings) < self.n_required:
+                continue
+            # Time gate
+            if (now - buf.first_seen) < self.min_unknown_sec:
+                continue
+            # Tightness gate
+            worst = self._min_pairwise_sim(list(buf.embeddings))
+            if worst < self.min_pairwise_sim:
+                # Tight enough samples haven't accumulated; leave for now.
+                # If the track is gone, gc_stale will drop the buffer later.
+                continue
+            # All gates pass → commit
+            uuid = self._commit(buf)
+            if uuid:
+                committed.append(uuid)
+        if committed:
+            log.info(
+                "try_commit_pending: committed %d pending buffer(s)", len(committed),
+            )
+        return committed
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> dict:
+        """Diagnostic snapshot for /who or a debug endpoint."""
+        return {
+            "enrolled_total": self.enrolled_count,
+            "merged_total": self.merged_count,
+            "rejected_total": self.rejected_count,
+            "active_buffers": len(self._buffers),
+            "buffers": {
+                tid: {
+                    "samples_buffered": len(buf.crops),
+                    "first_seen_ago": round(time.time() - buf.first_seen, 1),
+                    "committed_uuid": buf.committed_uuid,
+                }
+                for tid, buf in self._buffers.items()
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _commit(
+        self,
+        buf: _TrackBuffer,
+        name: str = "",
+        forced: bool = False,
+    ) -> str:
+        """Commit a buffered track into the gallery.
+
+        Decision path:
+          1. Compute the buffer's mean embedding (more reliable than any
+             single frame — averaging suppresses noise).
+          2. Compare against ALL existing centroids. If the best match's
+             cosine sim >= ``merge_thr``, append samples to that UUID
+             (merge path). This catches the "known person in bad lighting
+             showed up as 'uncertain' per-frame, but their buffer mean is
+             clearly them" case.
+          3. Otherwise, create a brand-new UUID.
+
+        Forced commits (from /set_name) ALWAYS create a new UUID with the
+        given name — the LLM has named this specific track, so honor the
+        intent even if the embedding is close to an existing identity.
+        (If the user has a twin in the gallery, forced commit is the right
+        choice; the LLM/operator made the call.)
+
+        Sets ``buf.committed_uuid`` so further observe() calls for this
+        track don't try to enroll again.
+        """
+        # 1. Try merging into an existing UUID (unless forced — see docstring)
+        target_uuid: Optional[str] = None
+        merged_into_name: str = ""
+        merged_sim: float = 0.0
+        if not forced and self.merge_thr > 0.0:
+            target_uuid, merged_into_name, merged_sim = self._find_merge_target(buf)
+
+        try:
+            if target_uuid is None:
+                # 2a. Create new UUID
+                uuid = self.gallery.create(
+                    name=name,
+                    source=("auto_enroll_forced" if forced else self.source_tag),
+                    first_track_id=int(buf.track_id),
+                    buffered_samples=len(buf.crops),
+                )
+            else:
+                # 2b. Merge into existing UUID
+                uuid = target_uuid
+
+            saved = self.gallery.add_samples(
+                uuid,
+                list(buf.crops),
+                embeddings=list(buf.embeddings),
+            )
+        except Exception as e:
+            log.exception("auto-enroll commit failed for track %d: %s", buf.track_id, e)
+            return ""
+
+        buf.committed_uuid = uuid
+        if target_uuid is None:
+            self.enrolled_count += 1
+            log.info(
+                "auto-enroll track=%d → NEW uuid=%s (samples=%d, forced=%s, name=%r)",
+                buf.track_id, uuid, len(saved), forced, name,
+            )
+        else:
+            self.merged_count += 1
+            log.info(
+                "auto-enroll track=%d → MERGED into uuid=%s name=%r (samples=%d, sim=%.3f)",
+                buf.track_id, uuid, merged_into_name, len(saved), merged_sim,
+            )
+
+        if self.on_committed is not None:
+            try:
+                self.on_committed(uuid, buf.track_id, len(saved))
+            except Exception as e:
+                log.warning("on_committed callback raised: %s", e)
+        return uuid
+
+    def _find_merge_target(
+        self, buf: _TrackBuffer,
+    ) -> Tuple[Optional[str], str, float]:
+        """Check if buf.embeddings' mean matches an existing ANON UUID strongly
+        enough to fold the new samples in. Returns ``(uuid, name, sim)`` of the
+        best ANON match if sim >= merge_thr, else ``(None, "", 0.0)``.
+
+        IMPORTANT: only ANON UUIDs (name="") are valid merge targets.
+        Named identities (sean, alice, ...) are NEVER auto-merged into,
+        because face embedding sim is unreliable enough that a passing
+        stranger could mistakenly contaminate a named person's identity.
+        Concrete example:
+            sean has UUID A (name="sean") in gallery.
+            stranger walks in, looks vaguely like sean.
+            buffer mean sim to A's centroid = 0.52 (>= merge_thr=0.50).
+            WITHOUT this guard: stranger's samples get folded into sean's UUID.
+                                → sean's centroid is polluted, sean's recognition
+                                  suffers for everyone going forward.
+            WITH this guard:    A is named → skipped. Create new anon UUID
+                                instead. LLM/operator can later confirm via
+                                /gallery/find_similar + /gallery/merge if
+                                they're really the same person.
+
+        Why use the buffer mean instead of per-frame embeddings:
+            The per-frame recognition pass already saw each individual
+            embedding and concluded "uncertain" (otherwise this track
+            wouldn't have buffered). But the MEAN of N tight samples is a
+            cleaner signal than any single frame — noise averages out,
+            identity signal stays. So the mean often crosses the merge
+            threshold even when no single frame did.
+
+        Example of legitimate auto-merge:
+            anon UUID X was created last session (face seen but not named).
+            Same person walks in again, gets buffered to a new track.
+            Buffer mean sim against X's centroid = 0.65.
+            X has name="" (anon) → merge into X (samples folded in).
+        """
+        if not buf.embeddings:
+            return None, "", 0.0
+        try:
+            feats, names, uuids = self.gallery.get_centroids()
+        except Exception as e:
+            log.warning("auto-enroll: could not read gallery centroids: %s", e)
+            return None, "", 0.0
+        if feats is None or feats.shape[0] == 0:
+            # Empty gallery — nothing to merge with
+            return None, "", 0.0
+
+        # Mean of buffer embeddings, L2-normalized
+        buf_mean = np.mean(np.stack(buf.embeddings, axis=0), axis=0)
+        n = float(np.linalg.norm(buf_mean))
+        if n < 1e-12:
+            return None, "", 0.0
+        buf_mean = (buf_mean / n).astype(np.float32)
+
+        # Cosine sims against all gallery centroids
+        sims = feats @ buf_mean
+        # Sort descending so we can pick the best ANON match (not just best
+        # overall, which might be a named UUID we must NOT merge into).
+        order = np.argsort(-sims)
+
+        for idx in order:
+            j = int(idx)
+            cand_sim = float(sims[j])
+            cand_name = names[j]
+            cand_uuid = uuids[j]
+            if cand_sim < self.merge_thr:
+                # Beyond this point all candidates are below threshold —
+                # nothing left to consider.
+                break
+            if cand_name and cand_name.strip():
+                # Named UUID — skip. Even if this is the closest match, we
+                # refuse to auto-merge into a named identity. Log so it's
+                # visible in demo what got rejected.
+                log.debug(
+                    "auto-enroll merge_target SKIP named uuid=%s name=%r sim=%.3f "
+                    "(named UUIDs never auto-merged into; will create new anon)",
+                    cand_uuid, cand_name, cand_sim,
+                )
+                continue
+            # Anonymous match — valid merge target
+            log.info(
+                "auto-enroll merge_target FOUND anon uuid=%s sim=%.3f "
+                "(sample fold-in)", cand_uuid, cand_sim,
+            )
+            return cand_uuid, cand_name, cand_sim
+
+        return None, "", 0.0
+
+    @staticmethod
+    def _min_pairwise_sim(embeddings: List[np.ndarray]) -> float:
+        """Return the WORST pairwise cosine sim across the buffer.
+
+        Using the worst pair (not the average) is intentional — one bad
+        sample in a tight cluster shouldn't enroll, even if every other
+        pair is fine. The threshold acts as a sanity guard against
+        BoTSORT track-id mix-ups.
+        """
+        if len(embeddings) < 2:
+            return 1.0  # vacuously tight
+        # Embeddings are already L2-normalized; dot product == cosine.
+        M = np.stack(embeddings, axis=0)
+        sims = M @ M.T
+        # Zero the diagonal so we don't pick up self-similarity
+        n = sims.shape[0]
+        sims[np.arange(n), np.arange(n)] = 1.0
+        # We want the WORST off-diagonal element.
+        off_diag = sims[~np.eye(n, dtype=bool)]
+        return float(off_diag.min())

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/auto_enroller.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/auto_enroller.py
@@ -214,7 +214,7 @@ class AutoEnroller:
 
         # Stats (for /who debug)
         self.enrolled_count = 0
-        self.merged_count = 0    # NEW: tracks merge-on-commit decisions
+        self.merged_count = 0  # NEW: tracks merge-on-commit decisions
         self.rejected_count = 0
 
     # ------------------------------------------------------------------
@@ -274,7 +274,9 @@ class AutoEnroller:
         buf = self._buffers.get(track_id)
         if buf is None:
             buf = _TrackBuffer(
-                track_id=track_id, first_seen=now, last_seen=now,
+                track_id=track_id,
+                first_seen=now,
+                last_seen=now,
             )
             self._buffers[track_id] = buf
 
@@ -310,7 +312,9 @@ class AutoEnroller:
         if worst < self.min_pairwise_sim:
             log.debug(
                 "auto-enroll track=%d skipped: pairwise=%.3f < %.3f",
-                track_id, worst, self.min_pairwise_sim,
+                track_id,
+                worst,
+                self.min_pairwise_sim,
             )
             self.rejected_count += 1
             # Don't drop the buffer — maybe later samples improve cohesion.
@@ -343,7 +347,8 @@ class AutoEnroller:
 
     def drop_track(self, track_id: int) -> None:
         """Explicitly drop a track's buffer (e.g. when track was identified
-        as a known person by a different path)."""
+        as a known person by a different path).
+        """
         self._buffers.pop(track_id, None)
 
     def gc_stale(self) -> int:
@@ -418,7 +423,8 @@ class AutoEnroller:
                 committed.append(uuid)
         if committed:
             log.info(
-                "try_commit_pending: committed %d pending buffer(s)", len(committed),
+                "try_commit_pending: committed %d pending buffer(s)",
+                len(committed),
             )
         return committed
 
@@ -508,13 +514,21 @@ class AutoEnroller:
             self.enrolled_count += 1
             log.info(
                 "auto-enroll track=%d → NEW uuid=%s (samples=%d, forced=%s, name=%r)",
-                buf.track_id, uuid, len(saved), forced, name,
+                buf.track_id,
+                uuid,
+                len(saved),
+                forced,
+                name,
             )
         else:
             self.merged_count += 1
             log.info(
                 "auto-enroll track=%d → MERGED into uuid=%s name=%r (samples=%d, sim=%.3f)",
-                buf.track_id, uuid, merged_into_name, len(saved), merged_sim,
+                buf.track_id,
+                uuid,
+                merged_into_name,
+                len(saved),
+                merged_sim,
             )
 
         if self.on_committed is not None:
@@ -525,7 +539,8 @@ class AutoEnroller:
         return uuid
 
     def _find_merge_target(
-        self, buf: _TrackBuffer,
+        self,
+        buf: _TrackBuffer,
     ) -> Tuple[Optional[str], str, float]:
         """Check if buf.embeddings' mean matches an existing ANON UUID strongly
         enough to fold the new samples in. Returns ``(uuid, name, sim)`` of the
@@ -601,13 +616,17 @@ class AutoEnroller:
                 log.debug(
                     "auto-enroll merge_target SKIP named uuid=%s name=%r sim=%.3f "
                     "(named UUIDs never auto-merged into; will create new anon)",
-                    cand_uuid, cand_name, cand_sim,
+                    cand_uuid,
+                    cand_name,
+                    cand_sim,
                 )
                 continue
             # Anonymous match — valid merge target
             log.info(
                 "auto-enroll merge_target FOUND anon uuid=%s sim=%.3f "
-                "(sample fold-in)", cand_uuid, cand_sim,
+                "(sample fold-in)",
+                cand_uuid,
+                cand_sim,
             )
             return cand_uuid, cand_name, cand_sim
 

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/config.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/config.py
@@ -1,54 +1,3 @@
-"""
-Single-source-of-truth configuration for the OM1 face recognition pipeline.
-
-All tunable parameters live here, organized by subsystem. Each parameter has:
-  - A default value (used when no CLI flag or /config override is set)
-  - A type and units
-  - A docstring explaining what it does, how it's used, and (where helpful)
-    an example or calibration guidance
-  - Where to find it at runtime (cfg key name, component constructor arg, etc.)
-
-This file is the ONLY place to look when:
-  - You need to tune a threshold and don't remember which file owns it
-  - You're debugging "why is X happening" and want to see all relevant knobs
-  - You're writing a new component and need to know what's already defined
-
-Architectural conventions
--------------------------
-1. Parameters here are GROUPED by which subsystem reads them.
-2. Many are also exposed as CLI flags in ``run.py`` (override at launch
-   time) and as hot-tunable keys in the ``cfg`` dict (settable via the
-   ``/config`` HTTP endpoint while the system is running).
-3. The ``DEFAULTS`` dict at the bottom is what gets seeded into the runtime
-   ``cfg`` dict at startup. Add new entries there to make them /config-tunable.
-
-How values flow at runtime
---------------------------
-Startup:
-    1. argparse reads CLI flags (--sim-thr=0.55 etc); defaults from this file.
-    2. Components are constructed with those values.
-    3. The DEFAULTS dict gets copied into the runtime ``cfg`` dict.
-
-Per-frame:
-    4. Main loop snapshots ``cfg`` under ``cfg_lock``.
-    5. Hot-tunable params (``sim_thr``, ``strict_margin``, ``loose_margin``,
-       blur mode etc.) are pushed into the relevant component via
-       ``face_tracker.set_thresholds(...)`` and similar.
-    6. Sticky params (auto-enroll thresholds, recog_interval) are NOT
-       re-read each frame — captured at component construction time.
-       Restart needed to change them.
-
-Via HTTP:
-    7. POST /config with {"set": {"sim_thr": 0.5}} updates the cfg dict
-       under cfg_lock. The next frame's snapshot picks up the new value.
-
-To find a parameter
--------------------
-Press Ctrl-F here for the parameter name. Each entry tells you the cfg
-key (if any), which file uses it, whether it's hot-tunable, and how to
-think about its value.
-"""
-
 from __future__ import annotations
 
 from typing import Any, Dict
@@ -302,6 +251,14 @@ AUTO_ENROLL_STALE_TRACK_SEC = 5.0
 #   survive the gap between finalize→unknown and re-identify resuming
 #   observations. 5.0 > 1.0, safe.
 
+# Dedicated auto-enroll quality gates (independent of the /selfie gates).
+# A face must clear BOTH before auto-enroll will buffer/commit it, so only
+# clear, frontal faces enter the gallery. These do NOT affect detection/
+# tracking/recognition (the global DETECTION_CONFIDENCE stays low so the
+# robot still SEES profiles/far faces) — they only gate enrollment.
+AUTO_ENROLL_MIN_CONF = 0.65  # min detector confidence to auto-enroll
+AUTO_ENROLL_MIN_FRONTALITY = 0.6  # min frontality (0=off .. 1=dead-on) to auto-enroll
+
 AUTO_ENROLL_MERGE_THR = 0.50
 # Cosine sim threshold for merging an auto-enroll buffer into an existing
 # UUID instead of creating a new one. Solves the 'known person in bad lighting'
@@ -511,7 +468,7 @@ SELFIE_MIN_FACE_PX = 30
 # - cfg key: "selfie_min_face_px"
 # - Hot-tunable: YES
 
-SELFIE_MIN_CONF = 0.4
+SELFIE_MIN_CONF = 0.65
 # Selfie per-frame quality gate: detector confidence.
 # - cfg key: "selfie_min_conf"
 # - Hot-tunable: YES

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/config.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/config.py
@@ -53,46 +53,41 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-
 # ============================================================================
 # 1. Face detection (SCRFD)
 # ============================================================================
 
 SCRFD_SIZE = 640
-"""SCRFD input resolution (square). 640 standard; 480 faster but worse on
-small faces.
-- Used in: scrfd.py TRTSCRFD(size=...)
-- cfg key: none (engine compile-time)
-- Hot-tunable: NO
-"""
+# SCRFD input resolution (square). 640 standard; 480 faster but worse on
+# small faces.
+# - Used in: scrfd.py TRTSCRFD(size=...)
+# - cfg key: none (engine compile-time)
+# - Hot-tunable: NO
 
 DETECTION_CONFIDENCE = 0.5
-"""Minimum face detection confidence. Below this, the detection is dropped
-before NMS. Lower → more recall (find more faces including profiles); higher
-→ more precision (only frontal/clear faces).
-- Used in: scrfd.detect(conf=...), face_tracker BoTSORT init, gallery/add_raw
-- cfg key: "conf"
-- Hot-tunable: YES via /config
-- Example: at 0.5, you reliably catch frontal faces ~3m away. At 0.3 you
-  also catch partial profiles but get more false-positive box wobbles.
-"""
+# Minimum face detection confidence. Below this, the detection is dropped
+# before NMS. Lower → more recall (find more faces including profiles); higher
+# → more precision (only frontal/clear faces).
+# - Used in: scrfd.detect(conf=...), face_tracker BoTSORT init, gallery/add_raw
+# - cfg key: "conf"
+# - Hot-tunable: YES via /config
+# - Example: at 0.5, you reliably catch frontal faces ~3m away. At 0.3 you
+#   also catch partial profiles but get more false-positive box wobbles.
 
 DETECTION_NMS = 0.4
-"""NMS IoU threshold. Two boxes with IoU above this are deduped.
-Higher → more aggressive dedup (must overlap a lot to merge); lower → more
-aggressive merging (closer faces get merged into one box).
-- Used in: scrfd.nms_thresh (pushed live on /config update)
-- cfg key: "nms"
-- Hot-tunable: YES
-"""
+# NMS IoU threshold. Two boxes with IoU above this are deduped.
+# Higher → more aggressive dedup (must overlap a lot to merge); lower → more
+# aggressive merging (closer faces get merged into one box).
+# - Used in: scrfd.nms_thresh (pushed live on /config update)
+# - cfg key: "nms"
+# - Hot-tunable: YES
 
 DETECTION_MAX_NUM = 0
-"""Hard cap on faces returned per frame. 0 = no limit. Useful when crowds
-spike and you want to bound the work.
-- Used in: scrfd.detect(max_num=...)
-- cfg key: "max_num"
-- Hot-tunable: YES
-"""
+# Hard cap on faces returned per frame. 0 = no limit. Useful when crowds
+# spike and you want to bound the work.
+# - Used in: scrfd.detect(max_num=...)
+# - cfg key: "max_num"
+# - Hot-tunable: YES
 
 
 # ============================================================================
@@ -100,48 +95,45 @@ spike and you want to bound the work.
 # ============================================================================
 
 SIM_THR = 0.55
-"""Cosine sim threshold below which we treat a match as 'unknown' regardless
-of margin. Top-1 floor.
-- Used in: selfie_logic.recognize_from_sims(min_sim=...),
-  face_tracker.FaceTracker(sim_thr=...)
-- cfg key: "sim_thr"
-- Hot-tunable: YES
-- Calibration: collect ~50 (same-person, different-frame) pairs and ~500
-  (different-person) pairs. Plot cosine sim distributions. Pick sim_thr at
-  the elbow of the cross-person distribution — typically 0.40-0.55 for
-  AdaFace IR101. Higher → more rejections in bad lighting; lower → more
-  false accepts.
-- Example: at 0.55, wendy in office light → match (sim=0.65). wendy in dim
-  hallway → might fall to 0.50 and become 'unknown'. Lower to 0.45 if this
-  happens too often.
-"""
+# Cosine sim threshold below which we treat a match as 'unknown' regardless
+# of margin. Top-1 floor.
+# - Used in: selfie_logic.recognize_from_sims(min_sim=...),
+#   face_tracker.FaceTracker(sim_thr=...)
+# - cfg key: "sim_thr"
+# - Hot-tunable: YES
+# - Calibration: collect ~50 (same-person, different-frame) pairs and ~500
+#   (different-person) pairs. Plot cosine sim distributions. Pick sim_thr at
+#   the elbow of the cross-person distribution — typically 0.40-0.55 for
+#   AdaFace IR101. Higher → more rejections in bad lighting; lower → more
+#   false accepts.
+# - Example: at 0.55, wendy in office light → match (sim=0.65). wendy in dim
+#   hallway → might fall to 0.50 and become 'unknown'. Lower to 0.45 if this
+#   happens too often.
 
 STRICT_MARGIN = 0.08
-"""top1 - top2 margin required for the 'confident' recognition tier. When
-the top-1 candidate's similarity exceeds top-2's by at least this much, we
-trust the match without verification.
-- Used in: selfie_logic.recognize_from_sims(strict_margin=...),
-  face_tracker.FaceTracker(strict_margin=...)
-- cfg key: "strict_margin"
-- Hot-tunable: YES
-- Calibration: with a small gallery (<50 ids), this can be tight (0.06-0.08).
-  With a large gallery (>200 ids), near-collisions are more common, so
-  loosen to 0.10-0.12 to avoid false confidence.
-- Example: top1=0.62 (wendy), top2=0.51 (alice) → margin=0.11 → confident.
-           top1=0.62 (wendy), top2=0.58 (alice) → margin=0.04 → not confident.
-"""
+# top1 - top2 margin required for the 'confident' recognition tier. When
+# the top-1 candidate's similarity exceeds top-2's by at least this much, we
+# trust the match without verification.
+# - Used in: selfie_logic.recognize_from_sims(strict_margin=...),
+#   face_tracker.FaceTracker(strict_margin=...)
+# - cfg key: "strict_margin"
+# - Hot-tunable: YES
+# - Calibration: with a small gallery (<50 ids), this can be tight (0.06-0.08).
+#   With a large gallery (>200 ids), near-collisions are more common, so
+#   loosen to 0.10-0.12 to avoid false confidence.
+# - Example: top1=0.62 (wendy), top2=0.51 (alice) → margin=0.11 → confident.
+#            top1=0.62 (wendy), top2=0.58 (alice) → margin=0.04 → not confident.
 
 LOOSE_MARGIN = 0.04
-"""top1 - top2 margin required for the 'tentative' recognition tier. Between
-strict_margin and loose_margin, we return the candidate but flag it as
-tentative — LLM should verify ('are you wendy?') instead of greeting by name.
-- Used in: same as strict_margin
-- cfg key: "loose_margin"
-- Hot-tunable: YES
-- Constraint: must be < strict_margin.
-- Example: top1=0.62, top2=0.57 → margin=0.05 → tentative.
-           top1=0.62, top2=0.59 → margin=0.03 → uncertain (don't commit).
-"""
+# top1 - top2 margin required for the 'tentative' recognition tier. Between
+# strict_margin and loose_margin, we return the candidate but flag it as
+# tentative — LLM should verify ('are you wendy?') instead of greeting by name.
+# - Used in: same as strict_margin
+# - cfg key: "loose_margin"
+# - Hot-tunable: YES
+# - Constraint: must be < strict_margin.
+# - Example: top1=0.62, top2=0.57 → margin=0.05 → tentative.
+#            top1=0.62, top2=0.59 → margin=0.03 → uncertain (don't commit).
 
 
 # ============================================================================
@@ -149,72 +141,65 @@ tentative — LLM should verify ('are you wendy?') instead of greeting by name.
 # ============================================================================
 
 RECOG_INTERVAL_SEC = 0.2
-"""Seconds between recognition attempts per track. Recognition is the
-expensive operation (AdaFace TRT inference); we don't need to re-recognize
-every frame for the same track. Lower → faster identification of new
-tracks; higher → lower GPU load.
-- Used in: face_tracker.FaceTracker(recog_interval=...)
-- Hot-tunable: NO (sticky)
-- Example: at 0.2s and 15fps, every 3rd frame we run recognition for a
-  given track. A new track gets 3 votes in ~0.6s → identified.
-"""
+# Seconds between recognition attempts per track. Recognition is the
+# expensive operation (AdaFace TRT inference); we don't need to re-recognize
+# every frame for the same track. Lower → faster identification of new
+# tracks; higher → lower GPU load.
+# - Used in: face_tracker.FaceTracker(recog_interval=...)
+# - Hot-tunable: NO (sticky)
+# - Example: at 0.2s and 15fps, every 3rd frame we run recognition for a
+#   given track. A new track gets 3 votes in ~0.6s → identified.
 
 VOTE_FRAMES = 3
-"""Number of recognition votes to collect before deciding identity. More
-votes = more robust against single-frame errors; fewer = faster decisions.
-- Used in: face_tracker.FaceTracker(vote_frames=...) + _finalize_identity
-- Hot-tunable: NO
-- Example: 3 votes with vote_threshold=0.5 means 2 of 3 must agree.
-"""
+# Number of recognition votes to collect before deciding identity. More
+# votes = more robust against single-frame errors; fewer = faster decisions.
+# - Used in: face_tracker.FaceTracker(vote_frames=...) + _finalize_identity
+# - Hot-tunable: NO
+# - Example: 3 votes with vote_threshold=0.5 means 2 of 3 must agree.
 
 VOTE_THRESHOLD = 0.5
-"""Fraction of votes a single name needs to win. 0.5 = simple majority.
-- Used in: face_tracker.FaceTracker(vote_threshold=...) + _finalize_identity
-- Hot-tunable: NO
-- Example: vote_frames=3, vote_threshold=0.5 → 2/3 wins.
-           vote_frames=3, vote_threshold=0.7 → all 3 must agree.
-"""
+# Fraction of votes a single name needs to win. 0.5 = simple majority.
+# - Used in: face_tracker.FaceTracker(vote_threshold=...) + _finalize_identity
+# - Hot-tunable: NO
+# - Example: vote_frames=3, vote_threshold=0.5 → 2/3 wins.
+#            vote_frames=3, vote_threshold=0.7 → all 3 must agree.
 
 MAX_RECOG_ATTEMPTS = 10
-"""Hard cap on recognition attempts per track before forcing a decision.
-Prevents indefinite 'identifying...' state on tracks that never get a
-clear majority.
-- Used in: face_tracker.FaceTracker(max_recog_attempts=...)
-- Hot-tunable: NO
-"""
+# Hard cap on recognition attempts per track before forcing a decision.
+# Prevents indefinite 'identifying...' state on tracks that never get a
+# clear majority.
+# - Used in: face_tracker.FaceTracker(max_recog_attempts=...)
+# - Hot-tunable: NO
 
 TRACK_BUFFER = 30
-"""BoTSORT frames to keep a 'lost' track alive (waiting for re-detection).
-Higher = better at handling brief occlusions but increases the chance of
-track-id mixups when two people swap positions.
-- Used in: face_tracker.FaceTracker(track_buffer=...)
-- Hot-tunable: NO
-- Frame-count, scales with FPS: 30 frames @ 15fps = 2 seconds of occlusion
-  tolerance. If you change CAMERA_FPS, scale this accordingly to maintain
-  the same wall-clock duration.
-- Example: at 15fps, a face occluded for <2s gets the same track_id back
-  via BoTSORT's Kalman prediction. After 2s, occlusion timeout fires and
-  a new track_id is assigned on re-detection.
-"""
+# BoTSORT frames to keep a 'lost' track alive (waiting for re-detection).
+# Higher = better at handling brief occlusions but increases the chance of
+# track-id mixups when two people swap positions.
+# - Used in: face_tracker.FaceTracker(track_buffer=...)
+# - Hot-tunable: NO
+# - Frame-count, scales with FPS: 30 frames @ 15fps = 2 seconds of occlusion
+#   tolerance. If you change CAMERA_FPS, scale this accordingly to maintain
+#   the same wall-clock duration.
+# - Example: at 15fps, a face occluded for <2s gets the same track_id back
+#   via BoTSORT's Kalman prediction. After 2s, occlusion timeout fires and
+#   a new track_id is assigned on re-detection.
 
 ARC_MAX_BS = 8
-"""AdaFace TRT max batch size. Capped by the engine's optimization profile.
-- Used in: face_tracker.FaceTracker(arc_max_bs=...)
-- Hot-tunable: NO (engine compile-time)
-"""
+# AdaFace TRT max batch size. Capped by the engine's optimization profile.
+# - Used in: face_tracker.FaceTracker(arc_max_bs=...)
+# - Hot-tunable: NO (engine compile-time)
 
 RE_IDENTIFY_INTERVAL_SEC = 1.0
-"""Seconds before retrying recognition on tracks that came back 'unknown'
-or 'tentative'. Handles the 'walking closer to camera' case — face that
-was blurry at distance becomes clear, give it another shot.
-- Used in: face_tracker.FaceTracker(re_identify_interval=...)
-- Hot-tunable: NO
-- Example: an unknown track tries again every 1 second. AutoEnroller may
-  have committed a UUID by then, in which case re-recognition succeeds.
-- Constraint check: must be < AUTO_ENROLL_STALE_TRACK_SEC (5.0) so the
-  AutoEnroller buffer for a track in the unknown→re-identify gap doesn't
-  get GC'd before observations resume. 1.0 < 5.0, safe.
-"""
+# Seconds before retrying recognition on tracks that came back 'unknown'
+# or 'tentative'. Handles the 'walking closer to camera' case — face that
+# was blurry at distance becomes clear, give it another shot.
+# - Used in: face_tracker.FaceTracker(re_identify_interval=...)
+# - Hot-tunable: NO
+# - Example: an unknown track tries again every 1 second. AutoEnroller may
+#   have committed a UUID by then, in which case re-recognition succeeds.
+# - Constraint check: must be < AUTO_ENROLL_STALE_TRACK_SEC (5.0) so the
+#   AutoEnroller buffer for a track in the unknown→re-identify gap doesn't
+#   get GC'd before observations resume. 1.0 < 5.0, safe.
 
 
 # ============================================================================
@@ -222,190 +207,218 @@ was blurry at distance becomes clear, give it another shot.
 # ============================================================================
 
 AUTO_ENROLL_MIN_SAMPLES = 3
-"""How many quality samples must accumulate before auto-enroll commits a
-new UUID. Lower → faster enrollment but more risk of mis-enrollment from
-BoTSORT track-id swaps.
-- Used in: auto_enroller.AutoEnroller(n_samples_required=...)
-- CLI: --auto-enroll-min-samples
-- Hot-tunable: NO (constructor-time)
-- Example: 3 with novelty_thr=0.97 and min_unknown_sec=1.0 means at least
-  3 distinct-enough samples within at least 1 second of observation.
-"""
+# How many quality samples must accumulate before auto-enroll commits a
+# new UUID. Lower → faster enrollment but more risk of misenrollment from
+# BoTSORT track-id swaps.
+# - Used in: auto_enroller.AutoEnroller(n_samples_required=...)
+# - CLI: --auto-enroll-min-samples
+# - Hot-tunable: NO (constructor-time)
+# - Example: 3 with novelty_thr=0.97 and min_unknown_sec=1.0 means at least
+#   3 distinct-enough samples within at least 1 second of observation.
 
-AUTO_ENROLL_MAX_BUFFER = 6
-"""Maximum samples kept per track in the rolling buffer. When full, oldest
-is dropped. Should be ≥ n_samples_required.
-- Used in: auto_enroller.AutoEnroller(max_buffer=...)
-- CLI: --auto-enroll-max-buffer
-- Hot-tunable: NO
-"""
+AUTO_ENROLL_MAX_BUFFER = 5
+# Maximum samples kept per track in the rolling buffer. When full, oldest
+# is dropped. Should be ≥ n_samples_required.
+# - Used in: auto_enroller.AutoEnroller(max_buffer=...)
+# - CLI: --auto-enroll-max-buffer
+# - Hot-tunable: NO
 
 AUTO_ENROLL_TIGHTNESS = 0.55
-"""Required pairwise cosine similarity (worst pair) across the sample
-buffer before enrollment fires. Filters out tracks where BoTSORT confused
-two visitors during occlusion.
-- Used in: auto_enroller.AutoEnroller(min_pairwise_sim=...)
-- CLI: --auto-enroll-tightness
-- Hot-tunable: NO
-- Calibration: should be lower than SIM_THR (0.55) since within-person sim
-  varies with lighting/angle. 0.55 is a conservative start; tune down to
-  ~0.45 if too few auto-enrollments fire, up to 0.60 if you see polluted
-  UUIDs (samples of two people enrolled together).
-"""
+# Required pairwise cosine similarity (worst pair) across the sample
+# buffer before enrollment fires. Filters out tracks where BoTSORT confused
+# two visitors during occlusion.
+# - Used in: auto_enroller.AutoEnroller(min_pairwise_sim=...)
+# - CLI: --auto-enroll-tightness
+# - Hot-tunable: NO
+# - Calibration: should be lower than SIM_THR (0.55) since within-person sim
+#   varies with lighting/angle. 0.55 is a conservative start; tune down to
+#   ~0.45 if too few auto-enrollments fire, up to 0.60 if you see polluted
+#   UUIDs (samples of two people enrolled together).
 
 AUTO_ENROLL_MIN_UNKNOWN_SEC = 1.0
-"""Track must have been visible/unknown for this many seconds before
-auto-enroll considers it. Filters out walk-throughs that produce a few
-quick samples but aren't really "engaged with the robot".
+# Track must have been visible/unknown for this many seconds before
+# auto-enroll considers it. Filters out walk-throughs that produce a few
+# quick samples but aren't really "engaged with the robot".
 
-Why 1.0s
---------
-At 1.5s the robot feels sluggish — a stranger walks up, stops, and waits
-1.5+s before being enrolled. At 1.0s the enrollment happens just as the
-robot finishes saying "hi" — feels natural.
+# Why 1.0s
+# --------
+# At 1.5s the robot feels sluggish — a stranger walks up, stops, and waits
+# 1.5+s before being enrolled. At 1.0s the enrollment happens just as the
+# robot finishes saying "hi" — feels natural.
 
-How this composes with other gates
-----------------------------------
-Auto-enroll commits when ALL of these are true:
-  - sample_count ≥ n_required (3)
-  - time elapsed ≥ min_unknown_sec
-  - pairwise tightness ≥ min_pairwise_sim
-  - each sample passes novelty + consistency checks
+# How this composes with other gates
+# ----------------------------------
+# Auto-enroll commits when ALL of these are true:
+#   - sample_count ≥ n_required (3)
+#   - time elapsed ≥ min_unknown_sec
+#   - pairwise tightness ≥ min_pairwise_sim
+#   - each sample passes novelty + consistency checks
 
-Other safeguards already filter walk-throughs:
-  - min_face_pixels=30 rejects distant pedestrians
-  - min_pairwise_sim=0.55 rejects samples where the face is moving/changing
-    too fast (walk-throughs)
-  - novelty_thr requires within-person variation (a single passing glance
-    rarely produces 3 distinct embeddings)
+# Other safeguards already filter walk-throughs:
+#   - min_face_pixels=30 rejects distant pedestrians
+#   - min_pairwise_sim=0.55 rejects samples where the face is moving/changing
+#     too fast (walk-throughs)
+#   - novelty_thr requires within-person variation (a single passing glance
+#     rarely produces 3 distinct embeddings)
 
-So min_unknown_sec is one of multiple independent filters; it doesn't
-need to be conservative on its own.
+# So min_unknown_sec is one of multiple independent filters; it doesn't
+# need to be conservative on its own.
 
-- Used in: auto_enroller.AutoEnroller(min_unknown_sec=...)
-- CLI: --auto-enroll-min-unknown-sec
-- Hot-tunable: NO
-- Calibration: at demo time, watch enrollment latency. If too many
-  walk-throughs enroll: raise to 1.5s. If robot feels slow: lower
-  to 0.7-0.8s.
-"""
+# - Used in: auto_enroller.AutoEnroller(min_unknown_sec=...)
+# - CLI: --auto-enroll-min-unknown-sec
+# - Hot-tunable: NO
+# - Calibration: at demo time, watch enrollment latency. If too many
+#   walk-throughs enroll: raise to 1.5s. If robot feels slow: lower
+#   to 0.7-0.8s.
 
 AUTO_ENROLL_MIN_FACE_PX = 26
-"""Minimum bbox short side for an auto-enroll sample. Below this, samples
-are dropped — too small to produce reliable embeddings.
+# Minimum bbox short side for an auto-enroll sample. Below this, samples
+# are dropped — too small to produce reliable embeddings.
 
-Sized for 640×480 camera (Unitree G1 default). 30 px short side ≈ 6.25%
-of frame height, equivalent to a person ~2-3m from the camera at ~60° FoV.
+# Sized for 640×480 camera (Unitree G1 default). 30 px short side ≈ 6.25%
+# of frame height, equivalent to a person ~2-3m from the camera at ~60° field of view.
 
-At higher camera resolutions, scale up to maintain the same physical
-distance threshold:
-  - 640×480  → 30 px
-  - 1280×720 → 50 px
-  - 1920×1080 → 75 px
+# At higher camera resolutions, scale up to maintain the same physical
+# distance threshold:
+#   - 640×480  → 30 px
+#   - 1280×720 → 50 px
+#   - 1920×1080 → 75 px
 
-- Used in: auto_enroller.AutoEnroller(min_face_pixels=...)
-- CLI: --auto-enroll-min-face-px
-- Hot-tunable: NO
-- Note: this is slightly looser than the per-frame recognition gate would
-  be — auto-enroll wants multiple samples anyway, so a single marginal
-  one isn't fatal. The pairwise-tightness check filters out noisy
-  embeddings before commit.
-"""
+# - Used in: auto_enroller.AutoEnroller(min_face_pixels=...)
+# - CLI: --auto-enroll-min-face-px
+# - Hot-tunable: NO
+# - Note: this is slightly looser than the per-frame recognition gate would
+#   be — auto-enroll wants multiple samples anyway, so a single marginal
+#   one isn't fatal. The pairwise-tightness check filters out noisy
+#   embeddings before commit.
 
-AUTO_ENROLL_NOVELTY_THR = 0.93
-"""Cosine sim threshold ABOVE which a new sample is rejected as a
-near-duplicate of what's already in the buffer (no new info to learn).
-
-Replaces the old time-based AUTO_ENROLL_CAPTURE_INTERVAL_SEC. The
-embedding-based approach guarantees that each buffered sample contributes
-new information about the person — different angle, expression, micro-
-motion — instead of "3 photos of the same pose taken 0.3s apart".
-
-The cosine sim is measured against the buffer's running mean.
-
-- Used in: auto_enroller.AutoEnroller(novelty_thr=...)
-- Hot-tunable: NO
-
-Calibration
------------
-0.97 is permissive — typical natural standing produces sim ≈ 0.85-0.95
-between consecutive frames (micro-movements, blinks, breathing). 0.95
-would be too strict (some valid samples rejected); 0.99 would let
-near-identical frames through.
-
-Comparison to selfie pipeline (SELFIE_NOVELTY_THR = 0.93):
-  - Selfie: user is actively moving/posing, sim drops easily below 0.93,
-    so the stricter threshold works fine.
-  - Auto-enroll: passive observation, sim stays higher because user isn't
-    deliberately changing pose; we need 0.97 to not starve the buffer.
-
-Edge case
----------
-A person standing perfectly still produces sim > 0.97 for every frame
-and never buffers more than 1 sample. In practice this doesn't happen —
-breathing, micro-saccades, and detection box wobble produce enough
-variation. If you observe a stalled buffer in production, loosen this
-to 0.98 or 0.99.
-"""
-
-AUTO_ENROLL_CONSISTENCY_THR = 0.50
-"""Cosine sim threshold BELOW which a new sample is rejected as too
-different from the buffer's running mean — likely indicates BoTSORT
-gave the same track_id to two different people during occlusion.
-
-Mirrors SELFIE_CONSISTENCY_THR. The pairwise tightness gate (at commit
-time) would also catch this, but consistency_thr rejects the bad sample
-earlier so the buffer doesn't get polluted.
-
-- Used in: auto_enroller.AutoEnroller(consistency_thr=...)
-- Hot-tunable: NO
-- Example: wendy was being buffered (samples 1, 2). She got briefly
-  occluded; alice walked into her track. Sample 3 of alice has sim ≈
-  0.15 to the running mean of wendy → rejected.
-"""
 
 AUTO_ENROLL_STALE_TRACK_SEC = 5.0
-"""Drop a track's buffer if no observe() in this long. Saves memory on
-tracks that walked out of frame.
-- Used in: auto_enroller.AutoEnroller(stale_track_sec=...)
-- Hot-tunable: NO
-- Constraint: must be > RE_IDENTIFY_INTERVAL_SEC (1.0) so buffers
-  survive the gap between finalize→unknown and re-identify resuming
-  observations. 5.0 > 1.0, safe.
-"""
+# Drop a track's buffer if no observe() in this long. Saves memory on
+# tracks that walked out of frame.
+# - Used in: auto_enroller.AutoEnroller(stale_track_sec=...)
+# - Hot-tunable: NO
+# - Constraint: must be > RE_IDENTIFY_INTERVAL_SEC (1.0) so buffers
+#   survive the gap between finalize→unknown and re-identify resuming
+#   observations. 5.0 > 1.0, safe.
 
 AUTO_ENROLL_MERGE_THR = 0.50
-"""Cosine sim threshold for merging an auto-enroll buffer into an existing
-UUID instead of creating a new one. Solves the 'known person in bad lighting'
-problem.
+# Cosine sim threshold for merging an auto-enroll buffer into an existing
+# UUID instead of creating a new one. Solves the 'known person in bad lighting'
+# problem.
 
-The problem
------------
-SIM_THR=0.55 is the per-frame floor for recognition: below it, a face is
-labeled 'uncertain' even if it's a known person. So wendy in dim hallway
-(top1_sim ≈ 0.52 per frame) gets buffered by AutoEnroller. Without this
-threshold, AutoEnroller would create a SECOND UUID for wendy every time
-she walks into different lighting.
+# The problem
+# -----------
+# SIM_THR=0.55 is the per-frame floor for recognition: below it, a face is
+# labeled 'uncertain' even if it's a known person. So wendy in dim hallway
+# (top1_sim ≈ 0.52 per frame) gets buffered by AutoEnroller. Without this
+# threshold, AutoEnroller would create a SECOND UUID for wendy every time
+# she walks into different lighting.
 
-The fix
--------
-Before committing a new UUID, AutoEnroller computes the MEAN of all
-buffered embeddings (more reliable than any single frame — noise averages
-out, identity signal stays). If that mean matches any existing UUID's
-centroid with sim >= AUTO_ENROLL_MERGE_THR, append the samples to that
-UUID instead.
+# The fix
+# -------
+# Before committing a new UUID, AutoEnroller computes the MEAN of all
+# buffered embeddings (more reliable than any single frame — noise averages
+# out, identity signal stays). If that mean matches any existing UUID's
+# centroid with sim >= AUTO_ENROLL_MERGE_THR, append the samples to that
+# UUID instead.
 
-- Used in: auto_enroller.AutoEnroller(merge_thr=...)
-- CLI: --auto-enroll-merge-thr
-- Hot-tunable: NO
-- Calibration: should be LOWER than SIM_THR (so the merge path can rescue
-  per-frame 'uncertain' decisions) but HIGHER than random-pair sim (~0.0-0.3
-  for cross-person on AdaFace) so true strangers still get new UUIDs.
-  Setting to 0.0 disables the merge path (always creates new UUIDs).
-- Example: wendy buffered with mean sim 0.62 to her existing centroid →
-  0.62 >= 0.50 → merge. Stranger buffered with mean sim 0.18 to nearest
-  centroid → 0.18 < 0.50 → new UUID.
-"""
+# - Used in: auto_enroller.AutoEnroller(merge_thr=...)
+# - CLI: --auto-enroll-merge-thr
+# - Hot-tunable: NO
+# - Calibration: should be LOWER than SIM_THR (so the merge path can rescue
+#   per-frame 'uncertain' decisions) but HIGHER than random-pair sim (~0.0-0.3
+#   for cross-person on AdaFace) so true strangers still get new UUIDs.
+#   Setting to 0.0 disables the merge path (always creates new UUIDs).
+# - Example: wendy buffered with mean sim 0.62 to her existing centroid →
+#   0.62 >= 0.50 → merge. Stranger buffered with mean sim 0.18 to nearest
+#   centroid → 0.18 < 0.50 → new UUID.
+
+
+# ============================================================================
+# 4b. Continuous sample refresh (sample_refresh.SampleRefreshManager)
+# ============================================================================
+#
+# Once a UUID exists in the gallery, every confident per-frame recognition
+# is a potential opportunity to enrich its centroid with a new feature
+# (different angle, lighting, expression). Three guards keep this safe:
+#
+#   A. Match confidence — sim must exceed sim_thr + REFRESH_MIN_EXTRA_CONFIDENCE
+#   B. Per-UUID rate limit — one attempt per REFRESH_MIN_INTERVAL_SEC
+#   C. Diversity — new sample's sim to centroid in
+#      [REFRESH_MIN_DIVERSITY_SIM, REFRESH_MAX_DIVERSITY_SIM]
+#
+# The gallery itself enforces a hard cap of MAX_SAMPLES_PER_UUID = 50 with
+# FIFO eviction, so disk stays bounded even with permissive guard settings.
+
+REFRESH_MIN_EXTRA_CONFIDENCE = 0.10
+# Guard A: minimum margin over sim_thr before a confident match qualifies
+# for sample refresh. Effective threshold = sim_thr + this value.
+# - Default: sim_thr=0.55, so refresh threshold = 0.65
+# - Higher → conservative (only enrich on rock-solid matches)
+# - Lower  → aggressive (more samples folded in, more risk of misattribution)
+# - Used in: SampleRefreshManager(min_extra_confidence=...)
+# - Hot-tunable: NO (would need to rebuild the manager)
+
+REFRESH_MIN_INTERVAL_SEC = 60.0
+# Guard B: minimum seconds between refresh attempts per UUID. Prevents a
+# single session from flooding a UUID with near-identical samples.
+# - Default: 60s. A 2-3 min conversation captures 2-3 samples, enough to
+#   pick up some pose/lighting variation without dominating disk I/O.
+# - Combined with the 50-sample FIFO cap, the centroid stays diverse over
+#   long deployments. Bumping this to 600s (10 min) is also reasonable for
+#   very long-running deployments where intra-session diversity matters
+#   less than cross-session diversity.
+# - Used in: SampleRefreshManager(min_refresh_interval_sec=...)
+
+REFRESH_MIN_DIVERSITY_SIM = 0.65
+# Guard C (lower bound): minimum sim between new sample's embedding and
+# the UUID's centroid for refresh to accept. Below this, treat as
+# likely-misidentification and skip.
+# - Default: 0.65 (matches sim_thr + min_extra_confidence by design)
+# - Higher → only very-similar samples get in (less drift risk)
+# - Used in: gallery.refresh_sample(min_diversity_sim=...)
+
+REFRESH_MAX_DIVERSITY_SIM = 0.92
+# Guard C (upper bound): maximum sim between new sample's embedding and
+# centroid. Above this, the sample is essentially a duplicate and adds no
+# feature diversity — skip to keep ring-buffer slots for novel samples.
+# - Default: 0.92 (allows minor pose/lighting variation, rejects near-clones)
+# - Lower → only sufficiently-different angles get in (more diverse centroid)
+# - Used in: gallery.refresh_sample(max_diversity_sim=...)
+
+
+# ============================================================================
+# 4c. Gallery sample cap (gallery.UUIDGallery)
+# ============================================================================
+
+MAX_SAMPLES_PER_UUID = 50
+# Hard cap on samples stored per UUID. When add_sample / refresh_sample
+# would push past this, the oldest sample is evicted (FIFO):
+# JPG removed, embeddings.npy row 0 dropped, centroid_sum decremented.
+
+# Disk math: 50 samples × ~50KB per aligned 112x112 JPG = 2.5MB per UUID.
+# 1000 UUIDs = 2.5GB. Effective ceiling for long-running deployments.
+
+# - Used in: UUIDGallery(max_samples_per_uuid=...)
+# - Hot-tunable: NO (would need cleanup pass to shrink existing UUIDs)
+
+LAST_SEEN_DISK_PERSIST_INTERVAL_SEC = 60.0
+# How often (in seconds) ``touch_last_seen`` flushes ``last_seen_at`` to
+# disk per UUID. In-memory ``rec.metadata["last_seen_at"]`` is updated on
+# every call (cheap); disk write is rate-limited.
+
+# Without this rate limit, touch_last_seen would write metadata.json
+# ~15×N times per second (N = visible faces), making it the dominant
+# source of disk I/O. With 60s persist, the same load is ~1 write per
+# minute per UUID — three orders of magnitude less churn.
+
+# The on-disk last_seen_at may lag the true last sighting by up to this
+# many seconds across a crash, which is fine for the ``/gallery/sweep_stale``
+# use case (cleanup thresholds are typically days or months).
+
+# - Used in: UUIDGallery(last_seen_persist_interval_sec=...)
+# - Hot-tunable: NO
 
 
 # ============================================================================
@@ -413,203 +426,182 @@ UUID instead.
 # ============================================================================
 
 SELFIE_WINDOW_SEC = 1.2
-"""Maximum time the selfie loop waits for samples. After this, returns
-whatever it's collected (or error if < SELFIE_MIN_SAMPLES).
-- cfg key: "selfie_window_sec"
-- Hot-tunable: YES
-- Sized for 15fps camera: 1.2s × 15fps = 18 frames in the window. After
-  quality gates (frontality, sharpness, brightness) filter ~40% out,
-  we still net ~10 usable frames — well above SELFIE_MIN_SAMPLES=1 and
-  enough room for SELFIE_MAX_SAMPLES=4. At 30fps you could drop to 0.8s.
-"""
+# Maximum time the selfie loop waits for samples. After this, returns
+# whatever it's collected (or error if < SELFIE_MIN_SAMPLES).
+# - cfg key: "selfie_window_sec"
+# - Hot-tunable: YES
+# - Sized for 15fps camera: 1.2s × 15fps = 18 frames in the window. After
+#   quality gates (frontality, sharpness, brightness) filter ~40% out,
+#   we still net ~10 usable frames — well above SELFIE_MIN_SAMPLES=1 and
+#   enough room for SELFIE_MAX_SAMPLES=4. At 30fps you could drop to 0.8s.
 
 SELFIE_TAP_INTERVAL_SEC = 0.07
-"""Sleep between selfie loop iterations to let new frames arrive. Should
-be slightly below the camera frame interval (1/fps) so we wake up just
-before each new frame is ready, without wasting CPU on busy-wait.
-- cfg key: "selfie_tap_interval_sec"
-- Hot-tunable: YES
-- For 15fps camera (frame interval = 66ms): 70ms is right.
-  For 30fps (frame interval = 33ms): 30-35ms would be the equivalent.
-- Caveat: the selfie loop ALSO uses a frame_token check to detect fresh
-  frames, so a slightly-too-short interval here doesn't double-process
-  the same frame — just wastes a tiny bit of CPU.
-"""
+# Sleep between selfie loop iterations to let new frames arrive. Should
+# be slightly below the camera frame interval (1/fps) so we wake up just
+# before each new frame is ready, without wasting CPU on busy-wait.
+# - cfg key: "selfie_tap_interval_sec"
+# - Hot-tunable: YES
+# - For 15fps camera (frame interval = 66ms): 70ms is right.
+#   For 30fps (frame interval = 33ms): 30-35ms would be the equivalent.
+# - Caveat: the selfie loop ALSO uses a frame_token check to detect fresh
+#   frames, so a slightly-too-short interval here doesn't double-process
+#   the same frame — just wastes a tiny bit of CPU.
 
 SELFIE_MIN_SAMPLES = 1
-"""Adaptive sample count: minimum number of valid frames to enroll. min=1
-lets static users enroll with just the first valid frame.
-- cfg key: "selfie_min_samples"
-- Hot-tunable: YES
-"""
+# Adaptive sample count: minimum number of valid frames to enroll. min=1
+# lets static users enroll with just the first valid frame.
+# - cfg key: "selfie_min_samples"
+# - Hot-tunable: YES
 
 SELFIE_MAX_SAMPLES = 4
-"""Maximum samples per selfie. Caps storage/embedding work per call.
-- cfg key: "selfie_max_samples"
-- Hot-tunable: YES
-"""
+# Maximum samples per selfie. Caps storage/embedding work per call.
+# - cfg key: "selfie_max_samples"
+# - Hot-tunable: YES
 
 SELFIE_MIN_ENGAGEMENT = 0.0025
-"""Engagement score floor below which a face isn't considered a selfie
-target. score = (bbox_area / frame_area) × frontality, in [0, 1].
+# Engagement score floor below which a face isn't considered a selfie
+# target. score = (bbox_area / frame_area) × frontality, in [0, 1].
 
-Calibrated for 640×480 camera + SELFIE_MIN_FACE_PX=30
----------------------------------------------------------
-The minimum sensible engagement is the score of a barely-passing face:
-30 px frontal face → score = (30×30) / (640×480) × 1.0 = 0.00293.
+# Calibrated for 640×480 camera + SELFIE_MIN_FACE_PX=30
+# ---------------------------------------------------------
+# The minimum sensible engagement is the score of a barely-passing face:
+# 30 px frontal face → score = (30×30) / (640×480) × 1.0 = 0.00293.
 
-0.0025 sits just below this with a small margin to absorb detection
-box wobble (1-2 px jitter can shrink bbox area by ~10%).
+# 0.0025 sits just below this with a small margin to absorb detection
+# box wobble (1-2 px jitter can shrink bbox area by ~10%).
 
-Behavior at this threshold:
-  - 30 px frontal face         → 0.00293 ✓ pass
-  - 30 px ¾-profile (f=0.85)   → 0.00249 ✗ borderline
-  - 25 px frontal face         → 0.00203 ✗ too small
-  - 40 px slight side (f=0.5)  → 0.00260 ✓ pass
-  - 70 px frontal at 1m        → 0.0159  ✓ pass (typical close selfie)
+# Behavior at this threshold:
+#   - 30 px frontal face         → 0.00293 ✓ pass
+#   - 30 px ¾-profile (f=0.85)   → 0.00249 ✗ borderline
+#   - 25 px frontal face         → 0.00203 ✗ too small
+#   - 40 px slight side (f=0.5)  → 0.00260 ✓ pass
+#   - 70 px frontal at 1m        → 0.0159  ✓ pass (typical close selfie)
 
-If you change CAMERA_WIDTH/HEIGHT or SELFIE_MIN_FACE_PX, recompute:
-    min_engagement = (min_face_px)² / (W × H) × 0.85
-where the 0.85 factor leaves margin for box jitter + frontality < 1.
+# If you change CAMERA_WIDTH/HEIGHT or SELFIE_MIN_FACE_PX, recompute:
+#     min_engagement = (min_face_px)² / (W × H) × 0.85
+# where the 0.85 factor leaves margin for box jitter + frontality < 1.
 
-- cfg key: "selfie_min_engagement"
-- Hot-tunable: YES
-- Multi-face role: engagement score is also used to PICK the best face
-  when multiple are detected (argmax). The floor here additionally
-  enables the ambiguity check (skips frames where top-1 and top-2 are
-  both above floor and close in score).
-"""
+# - cfg key: "selfie_min_engagement"
+# - Hot-tunable: YES
+# - Multi-face role: engagement score is also used to PICK the best face
+#   when multiple are detected (argmax). The floor here additionally
+#   enables the ambiguity check (skips frames where top-1 and top-2 are
+#   both above floor and close in score).
 
-SELFIE_AMBIGUITY_RATIO = 0.85
-"""top2/top1 engagement ratio above which we treat the frame as 'ambiguous'
-(two people equally addressing the robot). Frame skipped.
-- cfg key: "selfie_ambiguity_ratio"
-- Hot-tunable: YES
-- Example: 0.85 means if two faces have engagement scores 0.05 and 0.045,
-  ratio = 0.9 > 0.85 → ambiguous, skip frame.
-"""
+SELFIE_AMBIGUITY_RATIO = 0.80
+# top2/top1 engagement ratio above which we treat the frame as 'ambiguous'
+# (two people equally addressing the robot). Frame skipped.
+# - cfg key: "selfie_ambiguity_ratio"
+# - Hot-tunable: YES
+# - Example: 0.80 means if two faces have engagement scores 0.05 and 0.045,
+#   ratio = 0.9 > 0.80 → ambiguous, skip frame.
 
 SELFIE_MIN_FACE_PX = 30
-"""Selfie per-frame quality gate: bbox short side in pixels.
+# Selfie per-frame quality gate: bbox short side in pixels.
 
-Sized for 640×480 camera (Unitree G1 default). 30 px short side ≈ 6.25%
-of frame height, equivalent to a person ~2-3m from the camera at ~60° FoV.
+# Sized for 640×480 camera (Unitree G1 default). 30 px short side ≈ 6.25%
+# of frame height, equivalent to a person ~2-3m from the camera at ~60° field of view.
 
-At higher camera resolutions (e.g. 1280×720) you can raise this to keep
-the same physical distance threshold:
-  - 640×480  → 30 px
-  - 1280×720 → 50 px
-  - 1920×1080 → 75 px
+# At higher camera resolutions (e.g. 1280×720) you can raise this to keep
+# the same physical distance threshold:
+#   - 640×480  → 30 px
+#   - 1280×720 → 50 px
+#   - 1920×1080 → 75 px
 
-- cfg key: "selfie_min_face_px"
-- Hot-tunable: YES
-"""
+# - cfg key: "selfie_min_face_px"
+# - Hot-tunable: YES
 
 SELFIE_MIN_CONF = 0.4
-"""Selfie per-frame quality gate: detector confidence.
-- cfg key: "selfie_min_conf"
-- Hot-tunable: YES
-"""
+# Selfie per-frame quality gate: detector confidence.
+# - cfg key: "selfie_min_conf"
+# - Hot-tunable: YES
 
 SELFIE_MIN_FRONTALITY = 0.4
-"""Selfie per-frame quality gate: frontality from 5-point landmarks, [0,1].
-- cfg key: "selfie_min_frontality"
-- Hot-tunable: YES
-"""
+# Selfie per-frame quality gate: frontality from 5-point landmarks, [0,1].
+# - cfg key: "selfie_min_frontality"
+# - Hot-tunable: YES
 
 SELFIE_SHARP_THR = 5.0
-"""Selfie per-frame quality gate: Laplacian variance threshold for blur
-detection. Low value = blurry image → reject.
-- cfg key: "selfie_sharp_thr"
-- Hot-tunable: YES
-"""
+# Selfie per-frame quality gate: Laplacian variance threshold for blur
+# detection. Low value = blurry image → reject.
+# - cfg key: "selfie_sharp_thr"
+# - Hot-tunable: YES
 
 SELFIE_BRIGHTNESS_MIN = 30
-"""Selfie per-frame quality gate: minimum grayscale mean.
-- cfg key: "selfie_brightness_min"
-- Hot-tunable: YES
-"""
+# Selfie per-frame quality gate: minimum grayscale mean.
+# - cfg key: "selfie_brightness_min"
+# - Hot-tunable: YES
 
 SELFIE_BRIGHTNESS_MAX = 230
-"""Selfie per-frame quality gate: maximum grayscale mean.
-- cfg key: "selfie_brightness_max"
-- Hot-tunable: YES
-"""
+# Selfie per-frame quality gate: maximum grayscale mean.
+# - cfg key: "selfie_brightness_max"
+# - Hot-tunable: YES
 
 SELFIE_NOVELTY_THR = 0.93
-"""Cosine sim threshold above which a new selfie frame is 'too similar to
-what we already have' → skip (novelty check).
-- cfg key: "selfie_novelty_thr"
-- Hot-tunable: YES
-- Example: 0.93 means new frame must have at least ~7% angular variation
-  from the running mean.
-"""
+# Cosine sim threshold above which a new selfie frame is 'too similar to
+# what we already have' → skip (novelty check).
+# - cfg key: "selfie_novelty_thr"
+# - Hot-tunable: YES
+# - Example: 0.93 means new frame must have at least ~7% angular variation
+#   from the running mean.
 
 SELFIE_CONSISTENCY_THR = 0.50
-"""Cosine sim threshold below which a selfie frame is 'a different person
-from the one we started with' → skip (consistency check).
-- cfg key: "selfie_consistency_thr"
-- Hot-tunable: YES
-"""
+# Cosine sim threshold below which a selfie frame is 'a different person
+# from the one we started with' → skip (consistency check).
+# - cfg key: "selfie_consistency_thr"
+# - Hot-tunable: YES
 
 SELFIE_MERGE_THR = 0.5
-"""Cosine sim threshold for merging a selfie into an existing same-name UUID.
-- Used in: selfie_logic.resolve_target_id
-- cfg key: "selfie_merge_thr"
-- Hot-tunable: YES
-- Example: 0.45 means if a new wendy selfie matches an existing wendy UUID
-  at sim >= 0.45, append samples instead of creating a new UUID.
-"""
+# Cosine sim threshold for merging a selfie into an existing same-name UUID.
+# - Used in: selfie_logic.resolve_target_id
+# - cfg key: "selfie_merge_thr"
+# - Hot-tunable: YES
+# - Example: 0.45 means if a new wendy selfie matches an existing wendy UUID
+#   at sim >= 0.45, append samples instead of creating a new UUID.
 
 SELFIE_CROSS_NAME_THR = 0.60
-"""Cosine sim threshold above which a cross-name match triggers rejection
-(without force=True). Prevents 'Bob accidentally enrolled as Wendy'.
-- Used in: selfie_logic.resolve_target_id
-- cfg key: "selfie_cross_name_thr"
-- Hot-tunable: YES
-- Example: 0.60 means if face matches an existing UUID at sim >= 0.60 but
-  the names differ → reject and return 'face_belongs_to'.
-"""
+# Cosine sim threshold above which a cross-name match triggers rejection
+# (without force=True). Prevents 'Bob accidentally enrolled as Wendy'.
+# - Used in: selfie_logic.resolve_target_id
+# - cfg key: "selfie_cross_name_thr"
+# - Hot-tunable: YES
+# - Example: 0.60 means if face matches an existing UUID at sim >= 0.60 but
+#   the names differ → reject and return 'face_belongs_to'.
 
 
 # ============================================================================
 # 6. Pixelation / privacy blur
 # ============================================================================
 
-BLUR_ENABLED = True
-"""Whether to apply privacy pixelation at all.
-- cfg key: "blur"
-- Hot-tunable: YES
-"""
+BLUR_ENABLED = False
+# Whether to apply privacy pixelation at all.
+# - cfg key: "blur"
+# - Hot-tunable: YES
 
 BLUR_MODE = "all"
-"""Which faces to blur. Options: "all", "known", "unknown".
-- cfg key: "blur_mode"
-- Hot-tunable: YES
-- Example: "unknown" blurs only unrecognized faces (useful when you want
-  to show only enrolled people clearly).
-"""
+# Which faces to blur. Options: "all", "known", "unknown".
+# - cfg key: "blur_mode"
+# - Hot-tunable: YES
+# - Example: "unknown" blurs only unrecognized faces (useful when you want
+#   to show only enrolled people clearly).
 
 PIXEL_BLOCKS = 8
-"""Pixelation granularity: number of pixel blocks across the short side of
-the bbox. Smaller = coarser pixelation; larger = finer.
-- cfg key: "pixel_blocks"
-- Hot-tunable: YES
-"""
+# Pixelation granularity: number of pixel blocks across the short side of
+# the bbox. Smaller = coarser pixelation; larger = finer.
+# - cfg key: "pixel_blocks"
+# - Hot-tunable: YES
 
 PIXEL_MARGIN = 0.25
-"""Bbox expansion (fraction of size) before pixelation. Helps hide hair/ears
-that sit outside the detection box.
-- cfg key: "pixel_margin"
-- Hot-tunable: YES
-"""
+# Bbox expansion (fraction of size) before pixelation. Helps hide hair/ears
+# that sit outside the detection box.
+# - cfg key: "pixel_margin"
+# - Hot-tunable: YES
 
 PIXEL_NOISE = 0.0
-"""Gaussian noise sigma added to pixelated area. 0 = off. Helps prevent
-pixel-perfect un-pixelation attacks.
-- cfg key: "pixel_noise"
-- Hot-tunable: YES
-"""
+# Gaussian noise sigma added to pixelated area. 0 = off. Helps prevent
+# pixel-perfect un-pixelation attacks.
+# - cfg key: "pixel_noise"
+# - Hot-tunable: YES
 
 
 # ============================================================================
@@ -617,26 +609,23 @@ pixel-perfect un-pixelation attacks.
 # ============================================================================
 
 POSE_ENABLED = False
-"""Whether to run pose detection (YOLO11s-pose). Disabled by default for
-cost. Enable with --pose."""
+# Whether to run pose detection (YOLO11s-pose). Disabled by default for
+# cost. Enable with --pose.
 
 POSE_CONF = 0.5
-"""YOLO pose detector confidence threshold.
-- cfg key: "pose_conf"
-- Hot-tunable: YES
-"""
+# YOLO pose detector confidence threshold.
+# - cfg key: "pose_conf"
+# - Hot-tunable: YES
 
 POSE_MAX_NUM = 10
-"""Maximum persons per frame for pose detection.
-- cfg key: "pose_max_num"
-- Hot-tunable: YES
-"""
+# Maximum persons per frame for pose detection.
+# - cfg key: "pose_max_num"
+# - Hot-tunable: YES
 
 FALL_DETECTION_ENABLED = False
-"""Whether to run fall detection. Requires POSE_ENABLED.
-- cfg key: "fall_detection"
-- Hot-tunable: YES
-"""
+# Whether to run fall detection. Requires POSE_ENABLED.
+# - cfg key: "fall_detection"
+# - Hot-tunable: YES
 
 # Drawing options — all hot-tunable via /config
 DRAW_BOXES = False
@@ -652,19 +641,17 @@ SHOW_FPS = False
 # ============================================================================
 
 RECOG_TOPK = 4
-"""Maximum faces per frame to send to AdaFace. Caps per-frame GPU work in
-crowds. Should be ≤ AdaFace engine's max batch size.
-- CLI: --recog-topk
-- Hot-tunable: NO
-"""
+# Maximum faces per frame to send to AdaFace. Caps per-frame GPU work in
+# crowds. Should be ≤ AdaFace engine's max batch size.
+# - CLI: --recog-topk
+# - Hot-tunable: NO
 
 CROWD_THR = 12
-"""Hard crowd cap: if detected faces exceed this, skip recognition entirely
-for this frame (still draw boxes and blur). Prevents GPU starvation when
-a crowd shows up.
-- cfg key: "crowd_thr"
-- Hot-tunable: YES
-"""
+# Hard crowd cap: if detected faces exceed this, skip recognition entirely
+# for this frame (still draw boxes and blur). Prevents GPU starvation when
+# a crowd shows up.
+# - cfg key: "crowd_thr"
+# - Hot-tunable: YES
 
 
 # ============================================================================
@@ -674,27 +661,25 @@ a crowd shows up.
 CAMERA_DEVICE = "/dev/video0"
 CAMERA_WIDTH = 640
 CAMERA_HEIGHT = 480
-"""Camera resolution. Unitree G1's onboard camera default is 640×480.
+# Camera resolution. Unitree G1's onboard camera default is 640×480.
 
-All bbox-size thresholds (SELFIE_MIN_FACE_PX=30, AUTO_ENROLL_MIN_FACE_PX=30)
-are sized for this resolution. If you bump to a higher resolution camera,
-scale those thresholds proportionally:
-  640×480  → 30 px (current)
-  1280×720 → 50 px
-  1920×1080 → 75 px
-to keep the same effective "person distance" threshold.
-"""
+# All bbox-size thresholds (SELFIE_MIN_FACE_PX=30, AUTO_ENROLL_MIN_FACE_PX=30)
+# are sized for this resolution. If you bump to a higher resolution camera,
+# scale those thresholds proportionally:
+#   640×480  → 30 px (current)
+#   1280×720 → 50 px
+#   1920×1080 → 75 px
+# to keep the same effective "person distance" threshold.
 CAMERA_FPS = 15
-"""Capture frame rate. The Unitree G1 onboard camera runs at 15 fps.
+# Capture frame rate. The Unitree G1 onboard camera runs at 15 fps.
 
-All wall-clock-based parameters (recog_interval, min_unknown_sec,
-re_identify_interval, stale_track_sec) are independent of this — they
-measure seconds, not frames.
+# All wall-clock-based parameters (recog_interval, min_unknown_sec,
+# re_identify_interval, stale_track_sec) are independent of this — they
+# measure seconds, not frames.
 
-Frame-count parameters that DO scale with fps:
-  - TRACK_BUFFER (currently 30 = 2s @ 15fps)
-  - gc_stale modulo in run.py main loop (15 = ~1s @ 15fps)
-"""
+# Frame-count parameters that DO scale with fps:
+#   - TRACK_BUFFER (currently 30 = 2s @ 15fps)
+#   - gc_stale modulo in run.py main loop (15 = ~1s @ 15fps)
 
 LOCAL_RTSP_URL = "rtsp://localhost:8554/top_camera"
 RAW_LOCAL_RTSP_URL = "rtsp://localhost:8554/top_camera_raw"
@@ -702,7 +687,7 @@ RAW_LOCAL_RTSP_URL = "rtsp://localhost:8554/top_camera_raw"
 HTTP_HOST = "127.0.0.1"
 HTTP_PORT = 6793
 HTTP_LOOKBACK_SEC = 10.0
-"""Default lookback window for /who queries (seconds)."""
+# Default lookback window for /who queries (seconds).
 
 
 # ============================================================================
@@ -718,28 +703,23 @@ DEFAULTS: Dict[str, Any] = {
     "conf": DETECTION_CONFIDENCE,
     "nms": DETECTION_NMS,
     "max_num": DETECTION_MAX_NUM,
-
     # Recognition tier
     "sim_thr": SIM_THR,
     "strict_margin": STRICT_MARGIN,
     "loose_margin": LOOSE_MARGIN,
-
     # Blur
     "blur": BLUR_ENABLED,
     "blur_mode": BLUR_MODE,
     "pixel_blocks": PIXEL_BLOCKS,
     "pixel_margin": PIXEL_MARGIN,
     "pixel_noise": PIXEL_NOISE,
-
     # Pose
     "pose": POSE_ENABLED,
     "pose_conf": POSE_CONF,
     "pose_max_num": POSE_MAX_NUM,
     "fall_detection": FALL_DETECTION_ENABLED,
-
     # Crowd
     "crowd_thr": CROWD_THR,
-
     # Selfie pipeline (all hot-tunable via /config)
     "selfie_window_sec": SELFIE_WINDOW_SEC,
     "selfie_tap_interval_sec": SELFIE_TAP_INTERVAL_SEC,
@@ -757,7 +737,6 @@ DEFAULTS: Dict[str, Any] = {
     "selfie_consistency_thr": SELFIE_CONSISTENCY_THR,
     "selfie_merge_thr": SELFIE_MERGE_THR,
     "selfie_cross_name_thr": SELFIE_CROSS_NAME_THR,
-
     # Drawing
     "show_fps": SHOW_FPS,
     "draw_skeleton": DRAW_SKELETON,

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/config.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/config.py
@@ -1,0 +1,793 @@
+"""
+Single-source-of-truth configuration for the OM1 face recognition pipeline.
+
+All tunable parameters live here, organized by subsystem. Each parameter has:
+  - A default value (used when no CLI flag or /config override is set)
+  - A type and units
+  - A docstring explaining what it does, how it's used, and (where helpful)
+    an example or calibration guidance
+  - Where to find it at runtime (cfg key name, component constructor arg, etc.)
+
+This file is the ONLY place to look when:
+  - You need to tune a threshold and don't remember which file owns it
+  - You're debugging "why is X happening" and want to see all relevant knobs
+  - You're writing a new component and need to know what's already defined
+
+Architectural conventions
+-------------------------
+1. Parameters here are GROUPED by which subsystem reads them.
+2. Many are also exposed as CLI flags in ``run.py`` (override at launch
+   time) and as hot-tunable keys in the ``cfg`` dict (settable via the
+   ``/config`` HTTP endpoint while the system is running).
+3. The ``DEFAULTS`` dict at the bottom is what gets seeded into the runtime
+   ``cfg`` dict at startup. Add new entries there to make them /config-tunable.
+
+How values flow at runtime
+--------------------------
+Startup:
+    1. argparse reads CLI flags (--sim-thr=0.55 etc); defaults from this file.
+    2. Components are constructed with those values.
+    3. The DEFAULTS dict gets copied into the runtime ``cfg`` dict.
+
+Per-frame:
+    4. Main loop snapshots ``cfg`` under ``cfg_lock``.
+    5. Hot-tunable params (``sim_thr``, ``strict_margin``, ``loose_margin``,
+       blur mode etc.) are pushed into the relevant component via
+       ``face_tracker.set_thresholds(...)`` and similar.
+    6. Sticky params (auto-enroll thresholds, recog_interval) are NOT
+       re-read each frame — captured at component construction time.
+       Restart needed to change them.
+
+Via HTTP:
+    7. POST /config with {"set": {"sim_thr": 0.5}} updates the cfg dict
+       under cfg_lock. The next frame's snapshot picks up the new value.
+
+To find a parameter
+-------------------
+Press Ctrl-F here for the parameter name. Each entry tells you the cfg
+key (if any), which file uses it, whether it's hot-tunable, and how to
+think about its value.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+# ============================================================================
+# 1. Face detection (SCRFD)
+# ============================================================================
+
+SCRFD_SIZE = 640
+"""SCRFD input resolution (square). 640 standard; 480 faster but worse on
+small faces.
+- Used in: scrfd.py TRTSCRFD(size=...)
+- cfg key: none (engine compile-time)
+- Hot-tunable: NO
+"""
+
+DETECTION_CONFIDENCE = 0.5
+"""Minimum face detection confidence. Below this, the detection is dropped
+before NMS. Lower → more recall (find more faces including profiles); higher
+→ more precision (only frontal/clear faces).
+- Used in: scrfd.detect(conf=...), face_tracker BoTSORT init, gallery/add_raw
+- cfg key: "conf"
+- Hot-tunable: YES via /config
+- Example: at 0.5, you reliably catch frontal faces ~3m away. At 0.3 you
+  also catch partial profiles but get more false-positive box wobbles.
+"""
+
+DETECTION_NMS = 0.4
+"""NMS IoU threshold. Two boxes with IoU above this are deduped.
+Higher → more aggressive dedup (must overlap a lot to merge); lower → more
+aggressive merging (closer faces get merged into one box).
+- Used in: scrfd.nms_thresh (pushed live on /config update)
+- cfg key: "nms"
+- Hot-tunable: YES
+"""
+
+DETECTION_MAX_NUM = 0
+"""Hard cap on faces returned per frame. 0 = no limit. Useful when crowds
+spike and you want to bound the work.
+- Used in: scrfd.detect(max_num=...)
+- cfg key: "max_num"
+- Hot-tunable: YES
+"""
+
+
+# ============================================================================
+# 2. Recognition (AdaFace + tier-aware decision)
+# ============================================================================
+
+SIM_THR = 0.55
+"""Cosine sim threshold below which we treat a match as 'unknown' regardless
+of margin. Top-1 floor.
+- Used in: selfie_logic.recognize_from_sims(min_sim=...),
+  face_tracker.FaceTracker(sim_thr=...)
+- cfg key: "sim_thr"
+- Hot-tunable: YES
+- Calibration: collect ~50 (same-person, different-frame) pairs and ~500
+  (different-person) pairs. Plot cosine sim distributions. Pick sim_thr at
+  the elbow of the cross-person distribution — typically 0.40-0.55 for
+  AdaFace IR101. Higher → more rejections in bad lighting; lower → more
+  false accepts.
+- Example: at 0.55, wendy in office light → match (sim=0.65). wendy in dim
+  hallway → might fall to 0.50 and become 'unknown'. Lower to 0.45 if this
+  happens too often.
+"""
+
+STRICT_MARGIN = 0.08
+"""top1 - top2 margin required for the 'confident' recognition tier. When
+the top-1 candidate's similarity exceeds top-2's by at least this much, we
+trust the match without verification.
+- Used in: selfie_logic.recognize_from_sims(strict_margin=...),
+  face_tracker.FaceTracker(strict_margin=...)
+- cfg key: "strict_margin"
+- Hot-tunable: YES
+- Calibration: with a small gallery (<50 ids), this can be tight (0.06-0.08).
+  With a large gallery (>200 ids), near-collisions are more common, so
+  loosen to 0.10-0.12 to avoid false confidence.
+- Example: top1=0.62 (wendy), top2=0.51 (alice) → margin=0.11 → confident.
+           top1=0.62 (wendy), top2=0.58 (alice) → margin=0.04 → not confident.
+"""
+
+LOOSE_MARGIN = 0.04
+"""top1 - top2 margin required for the 'tentative' recognition tier. Between
+strict_margin and loose_margin, we return the candidate but flag it as
+tentative — LLM should verify ('are you wendy?') instead of greeting by name.
+- Used in: same as strict_margin
+- cfg key: "loose_margin"
+- Hot-tunable: YES
+- Constraint: must be < strict_margin.
+- Example: top1=0.62, top2=0.57 → margin=0.05 → tentative.
+           top1=0.62, top2=0.59 → margin=0.03 → uncertain (don't commit).
+"""
+
+
+# ============================================================================
+# 3. Face tracking + voting (face_tracker.FaceTracker)
+# ============================================================================
+
+RECOG_INTERVAL_SEC = 0.2
+"""Seconds between recognition attempts per track. Recognition is the
+expensive operation (AdaFace TRT inference); we don't need to re-recognize
+every frame for the same track. Lower → faster identification of new
+tracks; higher → lower GPU load.
+- Used in: face_tracker.FaceTracker(recog_interval=...)
+- Hot-tunable: NO (sticky)
+- Example: at 0.2s and 15fps, every 3rd frame we run recognition for a
+  given track. A new track gets 3 votes in ~0.6s → identified.
+"""
+
+VOTE_FRAMES = 3
+"""Number of recognition votes to collect before deciding identity. More
+votes = more robust against single-frame errors; fewer = faster decisions.
+- Used in: face_tracker.FaceTracker(vote_frames=...) + _finalize_identity
+- Hot-tunable: NO
+- Example: 3 votes with vote_threshold=0.5 means 2 of 3 must agree.
+"""
+
+VOTE_THRESHOLD = 0.5
+"""Fraction of votes a single name needs to win. 0.5 = simple majority.
+- Used in: face_tracker.FaceTracker(vote_threshold=...) + _finalize_identity
+- Hot-tunable: NO
+- Example: vote_frames=3, vote_threshold=0.5 → 2/3 wins.
+           vote_frames=3, vote_threshold=0.7 → all 3 must agree.
+"""
+
+MAX_RECOG_ATTEMPTS = 10
+"""Hard cap on recognition attempts per track before forcing a decision.
+Prevents indefinite 'identifying...' state on tracks that never get a
+clear majority.
+- Used in: face_tracker.FaceTracker(max_recog_attempts=...)
+- Hot-tunable: NO
+"""
+
+TRACK_BUFFER = 30
+"""BoTSORT frames to keep a 'lost' track alive (waiting for re-detection).
+Higher = better at handling brief occlusions but increases the chance of
+track-id mixups when two people swap positions.
+- Used in: face_tracker.FaceTracker(track_buffer=...)
+- Hot-tunable: NO
+- Frame-count, scales with FPS: 30 frames @ 15fps = 2 seconds of occlusion
+  tolerance. If you change CAMERA_FPS, scale this accordingly to maintain
+  the same wall-clock duration.
+- Example: at 15fps, a face occluded for <2s gets the same track_id back
+  via BoTSORT's Kalman prediction. After 2s, occlusion timeout fires and
+  a new track_id is assigned on re-detection.
+"""
+
+ARC_MAX_BS = 8
+"""AdaFace TRT max batch size. Capped by the engine's optimization profile.
+- Used in: face_tracker.FaceTracker(arc_max_bs=...)
+- Hot-tunable: NO (engine compile-time)
+"""
+
+RE_IDENTIFY_INTERVAL_SEC = 1.0
+"""Seconds before retrying recognition on tracks that came back 'unknown'
+or 'tentative'. Handles the 'walking closer to camera' case — face that
+was blurry at distance becomes clear, give it another shot.
+- Used in: face_tracker.FaceTracker(re_identify_interval=...)
+- Hot-tunable: NO
+- Example: an unknown track tries again every 1 second. AutoEnroller may
+  have committed a UUID by then, in which case re-recognition succeeds.
+- Constraint check: must be < AUTO_ENROLL_STALE_TRACK_SEC (5.0) so the
+  AutoEnroller buffer for a track in the unknown→re-identify gap doesn't
+  get GC'd before observations resume. 1.0 < 5.0, safe.
+"""
+
+
+# ============================================================================
+# 4. Auto-enrollment (auto_enroller.AutoEnroller)
+# ============================================================================
+
+AUTO_ENROLL_MIN_SAMPLES = 3
+"""How many quality samples must accumulate before auto-enroll commits a
+new UUID. Lower → faster enrollment but more risk of mis-enrollment from
+BoTSORT track-id swaps.
+- Used in: auto_enroller.AutoEnroller(n_samples_required=...)
+- CLI: --auto-enroll-min-samples
+- Hot-tunable: NO (constructor-time)
+- Example: 3 with novelty_thr=0.97 and min_unknown_sec=1.0 means at least
+  3 distinct-enough samples within at least 1 second of observation.
+"""
+
+AUTO_ENROLL_MAX_BUFFER = 6
+"""Maximum samples kept per track in the rolling buffer. When full, oldest
+is dropped. Should be ≥ n_samples_required.
+- Used in: auto_enroller.AutoEnroller(max_buffer=...)
+- CLI: --auto-enroll-max-buffer
+- Hot-tunable: NO
+"""
+
+AUTO_ENROLL_TIGHTNESS = 0.55
+"""Required pairwise cosine similarity (worst pair) across the sample
+buffer before enrollment fires. Filters out tracks where BoTSORT confused
+two visitors during occlusion.
+- Used in: auto_enroller.AutoEnroller(min_pairwise_sim=...)
+- CLI: --auto-enroll-tightness
+- Hot-tunable: NO
+- Calibration: should be lower than SIM_THR (0.55) since within-person sim
+  varies with lighting/angle. 0.55 is a conservative start; tune down to
+  ~0.45 if too few auto-enrollments fire, up to 0.60 if you see polluted
+  UUIDs (samples of two people enrolled together).
+"""
+
+AUTO_ENROLL_MIN_UNKNOWN_SEC = 1.0
+"""Track must have been visible/unknown for this many seconds before
+auto-enroll considers it. Filters out walk-throughs that produce a few
+quick samples but aren't really "engaged with the robot".
+
+Why 1.0s
+--------
+At 1.5s the robot feels sluggish — a stranger walks up, stops, and waits
+1.5+s before being enrolled. At 1.0s the enrollment happens just as the
+robot finishes saying "hi" — feels natural.
+
+How this composes with other gates
+----------------------------------
+Auto-enroll commits when ALL of these are true:
+  - sample_count ≥ n_required (3)
+  - time elapsed ≥ min_unknown_sec
+  - pairwise tightness ≥ min_pairwise_sim
+  - each sample passes novelty + consistency checks
+
+Other safeguards already filter walk-throughs:
+  - min_face_pixels=30 rejects distant pedestrians
+  - min_pairwise_sim=0.55 rejects samples where the face is moving/changing
+    too fast (walk-throughs)
+  - novelty_thr requires within-person variation (a single passing glance
+    rarely produces 3 distinct embeddings)
+
+So min_unknown_sec is one of multiple independent filters; it doesn't
+need to be conservative on its own.
+
+- Used in: auto_enroller.AutoEnroller(min_unknown_sec=...)
+- CLI: --auto-enroll-min-unknown-sec
+- Hot-tunable: NO
+- Calibration: at demo time, watch enrollment latency. If too many
+  walk-throughs enroll: raise to 1.5s. If robot feels slow: lower
+  to 0.7-0.8s.
+"""
+
+AUTO_ENROLL_MIN_FACE_PX = 26
+"""Minimum bbox short side for an auto-enroll sample. Below this, samples
+are dropped — too small to produce reliable embeddings.
+
+Sized for 640×480 camera (Unitree G1 default). 30 px short side ≈ 6.25%
+of frame height, equivalent to a person ~2-3m from the camera at ~60° FoV.
+
+At higher camera resolutions, scale up to maintain the same physical
+distance threshold:
+  - 640×480  → 30 px
+  - 1280×720 → 50 px
+  - 1920×1080 → 75 px
+
+- Used in: auto_enroller.AutoEnroller(min_face_pixels=...)
+- CLI: --auto-enroll-min-face-px
+- Hot-tunable: NO
+- Note: this is slightly looser than the per-frame recognition gate would
+  be — auto-enroll wants multiple samples anyway, so a single marginal
+  one isn't fatal. The pairwise-tightness check filters out noisy
+  embeddings before commit.
+"""
+
+AUTO_ENROLL_NOVELTY_THR = 0.93
+"""Cosine sim threshold ABOVE which a new sample is rejected as a
+near-duplicate of what's already in the buffer (no new info to learn).
+
+Replaces the old time-based AUTO_ENROLL_CAPTURE_INTERVAL_SEC. The
+embedding-based approach guarantees that each buffered sample contributes
+new information about the person — different angle, expression, micro-
+motion — instead of "3 photos of the same pose taken 0.3s apart".
+
+The cosine sim is measured against the buffer's running mean.
+
+- Used in: auto_enroller.AutoEnroller(novelty_thr=...)
+- Hot-tunable: NO
+
+Calibration
+-----------
+0.97 is permissive — typical natural standing produces sim ≈ 0.85-0.95
+between consecutive frames (micro-movements, blinks, breathing). 0.95
+would be too strict (some valid samples rejected); 0.99 would let
+near-identical frames through.
+
+Comparison to selfie pipeline (SELFIE_NOVELTY_THR = 0.93):
+  - Selfie: user is actively moving/posing, sim drops easily below 0.93,
+    so the stricter threshold works fine.
+  - Auto-enroll: passive observation, sim stays higher because user isn't
+    deliberately changing pose; we need 0.97 to not starve the buffer.
+
+Edge case
+---------
+A person standing perfectly still produces sim > 0.97 for every frame
+and never buffers more than 1 sample. In practice this doesn't happen —
+breathing, micro-saccades, and detection box wobble produce enough
+variation. If you observe a stalled buffer in production, loosen this
+to 0.98 or 0.99.
+"""
+
+AUTO_ENROLL_CONSISTENCY_THR = 0.50
+"""Cosine sim threshold BELOW which a new sample is rejected as too
+different from the buffer's running mean — likely indicates BoTSORT
+gave the same track_id to two different people during occlusion.
+
+Mirrors SELFIE_CONSISTENCY_THR. The pairwise tightness gate (at commit
+time) would also catch this, but consistency_thr rejects the bad sample
+earlier so the buffer doesn't get polluted.
+
+- Used in: auto_enroller.AutoEnroller(consistency_thr=...)
+- Hot-tunable: NO
+- Example: wendy was being buffered (samples 1, 2). She got briefly
+  occluded; alice walked into her track. Sample 3 of alice has sim ≈
+  0.15 to the running mean of wendy → rejected.
+"""
+
+AUTO_ENROLL_STALE_TRACK_SEC = 5.0
+"""Drop a track's buffer if no observe() in this long. Saves memory on
+tracks that walked out of frame.
+- Used in: auto_enroller.AutoEnroller(stale_track_sec=...)
+- Hot-tunable: NO
+- Constraint: must be > RE_IDENTIFY_INTERVAL_SEC (1.0) so buffers
+  survive the gap between finalize→unknown and re-identify resuming
+  observations. 5.0 > 1.0, safe.
+"""
+
+AUTO_ENROLL_MERGE_THR = 0.50
+"""Cosine sim threshold for merging an auto-enroll buffer into an existing
+UUID instead of creating a new one. Solves the 'known person in bad lighting'
+problem.
+
+The problem
+-----------
+SIM_THR=0.55 is the per-frame floor for recognition: below it, a face is
+labeled 'uncertain' even if it's a known person. So wendy in dim hallway
+(top1_sim ≈ 0.52 per frame) gets buffered by AutoEnroller. Without this
+threshold, AutoEnroller would create a SECOND UUID for wendy every time
+she walks into different lighting.
+
+The fix
+-------
+Before committing a new UUID, AutoEnroller computes the MEAN of all
+buffered embeddings (more reliable than any single frame — noise averages
+out, identity signal stays). If that mean matches any existing UUID's
+centroid with sim >= AUTO_ENROLL_MERGE_THR, append the samples to that
+UUID instead.
+
+- Used in: auto_enroller.AutoEnroller(merge_thr=...)
+- CLI: --auto-enroll-merge-thr
+- Hot-tunable: NO
+- Calibration: should be LOWER than SIM_THR (so the merge path can rescue
+  per-frame 'uncertain' decisions) but HIGHER than random-pair sim (~0.0-0.3
+  for cross-person on AdaFace) so true strangers still get new UUIDs.
+  Setting to 0.0 disables the merge path (always creates new UUIDs).
+- Example: wendy buffered with mean sim 0.62 to her existing centroid →
+  0.62 >= 0.50 → merge. Stranger buffered with mean sim 0.18 to nearest
+  centroid → 0.18 < 0.50 → new UUID.
+"""
+
+
+# ============================================================================
+# 5. Selfie enrollment (http_api._do_selfie + selfie_logic)
+# ============================================================================
+
+SELFIE_WINDOW_SEC = 1.2
+"""Maximum time the selfie loop waits for samples. After this, returns
+whatever it's collected (or error if < SELFIE_MIN_SAMPLES).
+- cfg key: "selfie_window_sec"
+- Hot-tunable: YES
+- Sized for 15fps camera: 1.2s × 15fps = 18 frames in the window. After
+  quality gates (frontality, sharpness, brightness) filter ~40% out,
+  we still net ~10 usable frames — well above SELFIE_MIN_SAMPLES=1 and
+  enough room for SELFIE_MAX_SAMPLES=4. At 30fps you could drop to 0.8s.
+"""
+
+SELFIE_TAP_INTERVAL_SEC = 0.07
+"""Sleep between selfie loop iterations to let new frames arrive. Should
+be slightly below the camera frame interval (1/fps) so we wake up just
+before each new frame is ready, without wasting CPU on busy-wait.
+- cfg key: "selfie_tap_interval_sec"
+- Hot-tunable: YES
+- For 15fps camera (frame interval = 66ms): 70ms is right.
+  For 30fps (frame interval = 33ms): 30-35ms would be the equivalent.
+- Caveat: the selfie loop ALSO uses a frame_token check to detect fresh
+  frames, so a slightly-too-short interval here doesn't double-process
+  the same frame — just wastes a tiny bit of CPU.
+"""
+
+SELFIE_MIN_SAMPLES = 1
+"""Adaptive sample count: minimum number of valid frames to enroll. min=1
+lets static users enroll with just the first valid frame.
+- cfg key: "selfie_min_samples"
+- Hot-tunable: YES
+"""
+
+SELFIE_MAX_SAMPLES = 4
+"""Maximum samples per selfie. Caps storage/embedding work per call.
+- cfg key: "selfie_max_samples"
+- Hot-tunable: YES
+"""
+
+SELFIE_MIN_ENGAGEMENT = 0.0025
+"""Engagement score floor below which a face isn't considered a selfie
+target. score = (bbox_area / frame_area) × frontality, in [0, 1].
+
+Calibrated for 640×480 camera + SELFIE_MIN_FACE_PX=30
+---------------------------------------------------------
+The minimum sensible engagement is the score of a barely-passing face:
+30 px frontal face → score = (30×30) / (640×480) × 1.0 = 0.00293.
+
+0.0025 sits just below this with a small margin to absorb detection
+box wobble (1-2 px jitter can shrink bbox area by ~10%).
+
+Behavior at this threshold:
+  - 30 px frontal face         → 0.00293 ✓ pass
+  - 30 px ¾-profile (f=0.85)   → 0.00249 ✗ borderline
+  - 25 px frontal face         → 0.00203 ✗ too small
+  - 40 px slight side (f=0.5)  → 0.00260 ✓ pass
+  - 70 px frontal at 1m        → 0.0159  ✓ pass (typical close selfie)
+
+If you change CAMERA_WIDTH/HEIGHT or SELFIE_MIN_FACE_PX, recompute:
+    min_engagement = (min_face_px)² / (W × H) × 0.85
+where the 0.85 factor leaves margin for box jitter + frontality < 1.
+
+- cfg key: "selfie_min_engagement"
+- Hot-tunable: YES
+- Multi-face role: engagement score is also used to PICK the best face
+  when multiple are detected (argmax). The floor here additionally
+  enables the ambiguity check (skips frames where top-1 and top-2 are
+  both above floor and close in score).
+"""
+
+SELFIE_AMBIGUITY_RATIO = 0.85
+"""top2/top1 engagement ratio above which we treat the frame as 'ambiguous'
+(two people equally addressing the robot). Frame skipped.
+- cfg key: "selfie_ambiguity_ratio"
+- Hot-tunable: YES
+- Example: 0.85 means if two faces have engagement scores 0.05 and 0.045,
+  ratio = 0.9 > 0.85 → ambiguous, skip frame.
+"""
+
+SELFIE_MIN_FACE_PX = 30
+"""Selfie per-frame quality gate: bbox short side in pixels.
+
+Sized for 640×480 camera (Unitree G1 default). 30 px short side ≈ 6.25%
+of frame height, equivalent to a person ~2-3m from the camera at ~60° FoV.
+
+At higher camera resolutions (e.g. 1280×720) you can raise this to keep
+the same physical distance threshold:
+  - 640×480  → 30 px
+  - 1280×720 → 50 px
+  - 1920×1080 → 75 px
+
+- cfg key: "selfie_min_face_px"
+- Hot-tunable: YES
+"""
+
+SELFIE_MIN_CONF = 0.4
+"""Selfie per-frame quality gate: detector confidence.
+- cfg key: "selfie_min_conf"
+- Hot-tunable: YES
+"""
+
+SELFIE_MIN_FRONTALITY = 0.4
+"""Selfie per-frame quality gate: frontality from 5-point landmarks, [0,1].
+- cfg key: "selfie_min_frontality"
+- Hot-tunable: YES
+"""
+
+SELFIE_SHARP_THR = 5.0
+"""Selfie per-frame quality gate: Laplacian variance threshold for blur
+detection. Low value = blurry image → reject.
+- cfg key: "selfie_sharp_thr"
+- Hot-tunable: YES
+"""
+
+SELFIE_BRIGHTNESS_MIN = 30
+"""Selfie per-frame quality gate: minimum grayscale mean.
+- cfg key: "selfie_brightness_min"
+- Hot-tunable: YES
+"""
+
+SELFIE_BRIGHTNESS_MAX = 230
+"""Selfie per-frame quality gate: maximum grayscale mean.
+- cfg key: "selfie_brightness_max"
+- Hot-tunable: YES
+"""
+
+SELFIE_NOVELTY_THR = 0.93
+"""Cosine sim threshold above which a new selfie frame is 'too similar to
+what we already have' → skip (novelty check).
+- cfg key: "selfie_novelty_thr"
+- Hot-tunable: YES
+- Example: 0.93 means new frame must have at least ~7% angular variation
+  from the running mean.
+"""
+
+SELFIE_CONSISTENCY_THR = 0.50
+"""Cosine sim threshold below which a selfie frame is 'a different person
+from the one we started with' → skip (consistency check).
+- cfg key: "selfie_consistency_thr"
+- Hot-tunable: YES
+"""
+
+SELFIE_MERGE_THR = 0.5
+"""Cosine sim threshold for merging a selfie into an existing same-name UUID.
+- Used in: selfie_logic.resolve_target_id
+- cfg key: "selfie_merge_thr"
+- Hot-tunable: YES
+- Example: 0.45 means if a new wendy selfie matches an existing wendy UUID
+  at sim >= 0.45, append samples instead of creating a new UUID.
+"""
+
+SELFIE_CROSS_NAME_THR = 0.60
+"""Cosine sim threshold above which a cross-name match triggers rejection
+(without force=True). Prevents 'Bob accidentally enrolled as Wendy'.
+- Used in: selfie_logic.resolve_target_id
+- cfg key: "selfie_cross_name_thr"
+- Hot-tunable: YES
+- Example: 0.60 means if face matches an existing UUID at sim >= 0.60 but
+  the names differ → reject and return 'face_belongs_to'.
+"""
+
+
+# ============================================================================
+# 6. Pixelation / privacy blur
+# ============================================================================
+
+BLUR_ENABLED = True
+"""Whether to apply privacy pixelation at all.
+- cfg key: "blur"
+- Hot-tunable: YES
+"""
+
+BLUR_MODE = "all"
+"""Which faces to blur. Options: "all", "known", "unknown".
+- cfg key: "blur_mode"
+- Hot-tunable: YES
+- Example: "unknown" blurs only unrecognized faces (useful when you want
+  to show only enrolled people clearly).
+"""
+
+PIXEL_BLOCKS = 8
+"""Pixelation granularity: number of pixel blocks across the short side of
+the bbox. Smaller = coarser pixelation; larger = finer.
+- cfg key: "pixel_blocks"
+- Hot-tunable: YES
+"""
+
+PIXEL_MARGIN = 0.25
+"""Bbox expansion (fraction of size) before pixelation. Helps hide hair/ears
+that sit outside the detection box.
+- cfg key: "pixel_margin"
+- Hot-tunable: YES
+"""
+
+PIXEL_NOISE = 0.0
+"""Gaussian noise sigma added to pixelated area. 0 = off. Helps prevent
+pixel-perfect un-pixelation attacks.
+- cfg key: "pixel_noise"
+- Hot-tunable: YES
+"""
+
+
+# ============================================================================
+# 7. Pose detection + fall detection
+# ============================================================================
+
+POSE_ENABLED = False
+"""Whether to run pose detection (YOLO11s-pose). Disabled by default for
+cost. Enable with --pose."""
+
+POSE_CONF = 0.5
+"""YOLO pose detector confidence threshold.
+- cfg key: "pose_conf"
+- Hot-tunable: YES
+"""
+
+POSE_MAX_NUM = 10
+"""Maximum persons per frame for pose detection.
+- cfg key: "pose_max_num"
+- Hot-tunable: YES
+"""
+
+FALL_DETECTION_ENABLED = False
+"""Whether to run fall detection. Requires POSE_ENABLED.
+- cfg key: "fall_detection"
+- Hot-tunable: YES
+"""
+
+# Drawing options — all hot-tunable via /config
+DRAW_BOXES = False
+DRAW_NAMES = False
+DRAW_SKELETON = False
+DRAW_POSE_BOXES = False
+DRAW_FALL_STATUS = False
+SHOW_FPS = False
+
+
+# ============================================================================
+# 8. Recognition strategy (main loop crowd handling)
+# ============================================================================
+
+RECOG_TOPK = 4
+"""Maximum faces per frame to send to AdaFace. Caps per-frame GPU work in
+crowds. Should be ≤ AdaFace engine's max batch size.
+- CLI: --recog-topk
+- Hot-tunable: NO
+"""
+
+CROWD_THR = 12
+"""Hard crowd cap: if detected faces exceed this, skip recognition entirely
+for this frame (still draw boxes and blur). Prevents GPU starvation when
+a crowd shows up.
+- cfg key: "crowd_thr"
+- Hot-tunable: YES
+"""
+
+
+# ============================================================================
+# 9. Camera / RTSP / HTTP
+# ============================================================================
+
+CAMERA_DEVICE = "/dev/video0"
+CAMERA_WIDTH = 640
+CAMERA_HEIGHT = 480
+"""Camera resolution. Unitree G1's onboard camera default is 640×480.
+
+All bbox-size thresholds (SELFIE_MIN_FACE_PX=30, AUTO_ENROLL_MIN_FACE_PX=30)
+are sized for this resolution. If you bump to a higher resolution camera,
+scale those thresholds proportionally:
+  640×480  → 30 px (current)
+  1280×720 → 50 px
+  1920×1080 → 75 px
+to keep the same effective "person distance" threshold.
+"""
+CAMERA_FPS = 15
+"""Capture frame rate. The Unitree G1 onboard camera runs at 15 fps.
+
+All wall-clock-based parameters (recog_interval, min_unknown_sec,
+re_identify_interval, stale_track_sec) are independent of this — they
+measure seconds, not frames.
+
+Frame-count parameters that DO scale with fps:
+  - TRACK_BUFFER (currently 30 = 2s @ 15fps)
+  - gc_stale modulo in run.py main loop (15 = ~1s @ 15fps)
+"""
+
+LOCAL_RTSP_URL = "rtsp://localhost:8554/top_camera"
+RAW_LOCAL_RTSP_URL = "rtsp://localhost:8554/top_camera_raw"
+
+HTTP_HOST = "127.0.0.1"
+HTTP_PORT = 6793
+HTTP_LOOKBACK_SEC = 10.0
+"""Default lookback window for /who queries (seconds)."""
+
+
+# ============================================================================
+# DEFAULTS dict — seeds the runtime cfg dict in run.py
+# ============================================================================
+#
+# Only keys present here are hot-tunable via /config. Adding a new key here
+# (plus a setter on the relevant component) makes a param /config-tunable.
+# Removing an entry locks that param to its startup value.
+
+DEFAULTS: Dict[str, Any] = {
+    # Detection
+    "conf": DETECTION_CONFIDENCE,
+    "nms": DETECTION_NMS,
+    "max_num": DETECTION_MAX_NUM,
+
+    # Recognition tier
+    "sim_thr": SIM_THR,
+    "strict_margin": STRICT_MARGIN,
+    "loose_margin": LOOSE_MARGIN,
+
+    # Blur
+    "blur": BLUR_ENABLED,
+    "blur_mode": BLUR_MODE,
+    "pixel_blocks": PIXEL_BLOCKS,
+    "pixel_margin": PIXEL_MARGIN,
+    "pixel_noise": PIXEL_NOISE,
+
+    # Pose
+    "pose": POSE_ENABLED,
+    "pose_conf": POSE_CONF,
+    "pose_max_num": POSE_MAX_NUM,
+    "fall_detection": FALL_DETECTION_ENABLED,
+
+    # Crowd
+    "crowd_thr": CROWD_THR,
+
+    # Selfie pipeline (all hot-tunable via /config)
+    "selfie_window_sec": SELFIE_WINDOW_SEC,
+    "selfie_tap_interval_sec": SELFIE_TAP_INTERVAL_SEC,
+    "selfie_min_samples": SELFIE_MIN_SAMPLES,
+    "selfie_max_samples": SELFIE_MAX_SAMPLES,
+    "selfie_min_engagement": SELFIE_MIN_ENGAGEMENT,
+    "selfie_ambiguity_ratio": SELFIE_AMBIGUITY_RATIO,
+    "selfie_min_face_px": SELFIE_MIN_FACE_PX,
+    "selfie_min_conf": SELFIE_MIN_CONF,
+    "selfie_min_frontality": SELFIE_MIN_FRONTALITY,
+    "selfie_sharp_thr": SELFIE_SHARP_THR,
+    "selfie_brightness_min": SELFIE_BRIGHTNESS_MIN,
+    "selfie_brightness_max": SELFIE_BRIGHTNESS_MAX,
+    "selfie_novelty_thr": SELFIE_NOVELTY_THR,
+    "selfie_consistency_thr": SELFIE_CONSISTENCY_THR,
+    "selfie_merge_thr": SELFIE_MERGE_THR,
+    "selfie_cross_name_thr": SELFIE_CROSS_NAME_THR,
+
+    # Drawing
+    "show_fps": SHOW_FPS,
+    "draw_skeleton": DRAW_SKELETON,
+    "draw_pose_boxes": DRAW_POSE_BOXES,
+    "draw_fall_status": DRAW_FALL_STATUS,
+}
+
+
+# ============================================================================
+# Hot-tunability quick reference
+# ============================================================================
+#
+# YES — via POST /config {"set": {...}} while system is running:
+#   conf, nms, max_num
+#   sim_thr, strict_margin, loose_margin
+#   blur, blur_mode, pixel_blocks, pixel_margin, pixel_noise
+#   pose, pose_conf, pose_max_num, fall_detection
+#   crowd_thr
+#   selfie_* (all selfie pipeline knobs)
+#   show_fps, draw_*
+#
+# NO — restart required (controllable via CLI flags at startup):
+#   AUTO_ENROLL_* (auto_enroller constructor-time)
+#   RECOG_INTERVAL_SEC, VOTE_FRAMES, VOTE_THRESHOLD, MAX_RECOG_ATTEMPTS,
+#     TRACK_BUFFER, ARC_MAX_BS, RE_IDENTIFY_INTERVAL_SEC
+#     (face_tracker constructor-time)
+#   SCRFD_SIZE, AdaFace engine path (engine compile-time)
+#   Camera / RTSP / HTTP bindings
+#
+# To make a constructor-time param hot-tunable:
+#   1. Add the key to DEFAULTS above
+#   2. Add a setter on the relevant component (like FaceTracker.set_thresholds)
+#   3. Push the value from the main loop's per-frame cfg snapshot

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -254,9 +254,7 @@ class FaceTracker:
         # UUID to a different one. Signature: (track_id, old_uuid, new_uuid).
         # Set as a plain attribute (like on_unknown_sample) by run.py, wired to
         # the auto-merge handler. None = feature off.
-        self.on_identity_flip: Optional[
-            Callable[[int, str, str], None]
-        ] = None
+        self.on_identity_flip: Optional[Callable[[int, str, str], None]] = None
 
         # Gallery (set via set_gallery). All three arrays are parallel —
         # row i of _gal_feats has name _gal_labels[i] and UUID _gal_uuids[i].

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -1,17 +1,31 @@
 """
-Face tracker with BoTSORT + low-frequency face recognition.
+Face tracker with BoTSORT + low-frequency, tier-aware face recognition.
 
 Architecture:
   Every frame:  SCRFD detect → BoTSORT track (persistent IDs)
-  Low freq:     For unidentified tracks → AdaFace embed → vote → assign identity
-  Once matched: Identity sticks to track ID until track is lost
+  Low freq:     For unidentified tracks → AdaFace embed → margin-aware
+                recognition → multi-frame voting → assign identity
+  Once matched: Identity sticks to track ID until track is lost.
+
+Recognition tiers (see selfie_logic.recognize_from_sims):
+  - "confident": top1 - top2 margin >= strict_margin → trust this match
+  - "tentative": top1 - top2 margin >= loose_margin → likely but ask to verify
+  - "uncertain": below loose_margin or top1 below sim_thr → "unknown" vote
+
+Voting decision (see _finalize_identity):
+  1. If any name has >= vote_threshold fraction of CONFIDENT votes → identified
+     with tier="confident".
+  2. Else if any name has >= vote_threshold fraction of CONFIDENT+TENTATIVE
+     votes → identified with tier="tentative" (caller should verify with user).
+  3. Otherwise → unknown.
 
 Usage:
-    tracker = FaceTracker(arc=arc_engine)
+    tracker = FaceTracker(arc=arc_engine, sim_thr=0.45,
+                          strict_margin=0.08, loose_margin=0.04)
     tracker.set_gallery(feats, labels)
     # Per frame:
     results = tracker.update(frame, dets, kpss)
-    # results = [TrackResult(track_id=1, bbox=..., name="wendy (0.72)", ...), ...]
+    # results = [TrackResult(track_id=1, raw_name="wendy", tier="confident", ...), ...]
 """
 
 from __future__ import annotations
@@ -20,49 +34,132 @@ import logging
 import time
 from collections import Counter
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import cv2
 import numpy as np
 
+from . import selfie_logic as sl
+
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
 
 
 @dataclass
 class TrackResult:
-    """Per-track output each frame."""
+    """Per-track output each frame.
+
+    Fields
+    ------
+    track_id : int
+        Persistent BoTSORT id; survives short occlusions.
+    bbox : (x1, y1, x2, y2)
+        Face bounding box in image coordinates.
+    conf : float
+        BoTSORT detection confidence for this frame.
+    raw_name : str | None
+        Plain identity label, e.g. ``"wendy"``, or ``None`` if not yet voted.
+        Use this for downstream tracking (WhoTracker, fall match, etc.).
+    name : str | None
+        Display string with score, e.g. ``"wendy (0.72)"`` or ``"wendy? (0.62)"``.
+        Use this for on-frame overlays/drawing.
+    sim : float
+        Average cosine similarity over the winning votes (0 if unknown).
+    tier : str
+        ``"confident"`` / ``"tentative"`` / ``"uncertain"``. Drives downstream
+        UX (e.g. whether the robot greets by name or asks to verify).
+    uuid : str | None
+        Stable identity ID from the gallery (UUID4 hex), or ``None`` if the
+        track is unidentified. Names can change via ``set_name``; UUIDs
+        cannot. Downstream layers (HttpAPI, audit log) should reference
+        identities by UUID rather than name.
+    is_known : bool
+        True only when ``tier == "confident"``. Kept for back-compat with
+        callers (e.g. blur logic) that previously had only a boolean signal.
+    """
 
     track_id: int
-    bbox: Tuple[int, int, int, int]  # x1, y1, x2, y2
+    bbox: Tuple[int, int, int, int]
     conf: float
-    name: Optional[str] = None  # display name (e.g. "wendy (0.72)" or "wendy? (0.62)")
-    sim: float = 0.0  # best similarity score
-    is_known: bool = False  # True only after vote confirmed
+    raw_name: Optional[str] = None
+    name: Optional[str] = None
+    sim: float = 0.0
+    tier: str = sl.TIER_UNCERTAIN
+    uuid: Optional[str] = None
+    is_known: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Internal state
+# ---------------------------------------------------------------------------
 
 
 @dataclass
 class _TrackIdentity:
-    """Internal identity state for one track."""
+    """Internal identity state accumulated for one BoTSORT track.
+
+    Lifecycle: new → identifying → (identified | unknown)
+    On re_identify_interval, "unknown" or low-confidence "identified" tracks
+    are reset back to "new" so recognition can retry on a clearer frame.
+    """
 
     track_id: int
-    status: str = "new"  # new → identifying → identified / unknown
+    status: str = "new"  # new | identifying | identified | unknown
+
+    # Decided identity (after _finalize_identity)
     name: Optional[str] = None
+    uuid: Optional[str] = None  # gallery UUID of the winning name (None if unknown)
     sim: float = 0.0
-    # Embedding votes collected during identification
+    tier: str = sl.TIER_UNCERTAIN
+
+    # Votes collected during the identifying phase.
+    # Length-aligned lists: vote_names[i] is the predicted name for vote i,
+    # vote_uuids[i] is the gallery UUID that name maps to (parallel; needed
+    # because multiple UUIDs can share a name), vote_tiers[i] is the tier
+    # of that prediction, vote_sims[i] is the top-1 sim. "unknown" entries
+    # are kept (count toward total votes) but excluded from naming decisions
+    # in _finalize_identity.
     vote_names: List[str] = field(default_factory=list)
+    vote_uuids: List[Optional[str]] = field(default_factory=list)
+    vote_tiers: List[str] = field(default_factory=list)
     vote_sims: List[float] = field(default_factory=list)
     embeddings: List[np.ndarray] = field(default_factory=list)
-    # Timing
+
+    # Timing & bookkeeping
     first_seen: float = 0.0
     last_recog_time: float = 0.0
     frames_seen: int = 0
     recog_attempts: int = 0
-    # Unknown capture state
-    unknown_since: float = 0.0  # when status first became unknown (0 = not unknown)
+    # When >0, marks when this track first became (or stayed) unknown.
+    # Used by the auto-enroll system to time how long a face has been
+    # unknown.
+    unknown_since: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# FaceTracker
+# ---------------------------------------------------------------------------
 
 
 class FaceTracker:
-    """BoTSORT face tracker with low-frequency recognition and multi-frame voting.
+    """BoTSORT face tracker with tier-aware recognition and multi-frame voting.
+
+    Recognition flow per frame:
+
+      1. BoTSORT assigns a track_id to each SCRFD detection (persistent IDs).
+      2. For tracks in ``"new"`` or ``"identifying"`` state that haven't been
+         re-checked within ``recog_interval`` seconds, queue them for AdaFace
+         embedding extraction.
+      3. Embed in a single batched pass (one TRT call for all queued tracks).
+      4. For each track, run :func:`selfie_logic.recognize_from_sims` to get
+         ``(name, tier, top1_sim, top2_sim)``. Push that into the track's
+         vote history.
+      5. Once a track has ``vote_frames`` votes (or hit ``max_recog_attempts``),
+         call :meth:`_finalize_identity` to decide.
 
     Parameters
     ----------
@@ -71,17 +168,27 @@ class FaceTracker:
     recog_interval : float
         Seconds between recognition attempts per track (default 0.3).
     vote_frames : int
-        Recognition frames to collect before voting (default 3).
+        Number of votes to collect before deciding identity (default 3).
     vote_threshold : float
-        Fraction of votes needed to confirm identity (default 0.5).
+        Fraction of votes a single name needs to win (default 0.5).
     max_recog_attempts : int
-        Max attempts before marking as "unknown" (default 10).
+        Hard cap on recognition attempts per track (default 10).
     sim_thr : float
-        Cosine similarity threshold for match (default 0.4).
+        Top-1 cosine threshold below which a vote is "uncertain" (default 0.4).
+    strict_margin : float
+        ``top1 - top2`` required for a vote to be "confident" (default 0.08).
+    loose_margin : float
+        ``top1 - top2`` required for a vote to be at least "tentative"
+        (default 0.04). Must be < ``strict_margin``.
     track_buffer : int
         BoTSORT frames to keep lost tracks alive (default 60).
     arc_max_bs : int
-        Max batch size for AdaFace inference (default 8).
+        AdaFace TRT max batch size (default 8).
+    det_conf : float
+        SCRFD detection confidence; passed to BoTSORT for tier alignment.
+    re_identify_interval : float
+        Seconds before retrying recognition on "unknown" or marginal tracks.
+        0 disables retry (default 3.0).
     """
 
     def __init__(
@@ -93,10 +200,15 @@ class FaceTracker:
         vote_threshold: float = 0.5,
         max_recog_attempts: int = 10,
         sim_thr: float = 0.4,
+        strict_margin: float = 0.08,
+        loose_margin: float = 0.04,
         track_buffer: int = 60,
         arc_max_bs: int = 8,
         det_conf: float = 0.5,
         re_identify_interval: float = 3.0,
+        on_unknown_sample: Optional[
+            "Callable[[int, np.ndarray, np.ndarray, Tuple[int,int,int,int], str], None]"
+        ] = None,
     ):
         self.arc = arc
         self.recog_interval = float(recog_interval)
@@ -104,12 +216,21 @@ class FaceTracker:
         self.vote_threshold = float(vote_threshold)
         self.max_recog_attempts = int(max_recog_attempts)
         self.sim_thr = float(sim_thr)
+        self.strict_margin = float(strict_margin)
+        self.loose_margin = float(loose_margin)
         self.arc_max_bs = int(arc_max_bs)
         self.re_identify_interval = float(re_identify_interval)
+        # Callback fired once per recognition pass per track, regardless of
+        # tier. Signature: (track_id, aligned_crop, embedding, bbox, tier).
+        # Used by AutoEnroller to buffer unknown faces and drop committed
+        # ones — keeping face_tracker unaware of storage concerns.
+        self.on_unknown_sample = on_unknown_sample
 
-        # Gallery (set via set_gallery)
+        # Gallery (set via set_gallery). All three arrays are parallel —
+        # row i of _gal_feats has name _gal_labels[i] and UUID _gal_uuids[i].
         self._gal_feats: Optional[np.ndarray] = None
         self._gal_labels: List[str] = []
+        self._gal_uuids: List[str] = []
 
         # BoTSORT tracker — align thresholds with SCRFD det_conf
         self._det_conf = float(det_conf)
@@ -125,9 +246,13 @@ class FaceTracker:
         # Current frame faces (for status queries)
         self._current_faces: list = []
 
+    # ------------------------------------------------------------------
+    # Setup / runtime config
+    # ------------------------------------------------------------------
+
     @staticmethod
     def _init_tracker(track_buffer: int, det_conf: float = 0.5):
-        """Initialize BoTSORT tracker with thresholds aligned to detection confidence."""
+        """Initialize BoTSORT with thresholds aligned to detection confidence."""
         from boxmot import BotSort
 
         high_thresh = max(det_conf, 0.3)
@@ -154,14 +279,133 @@ class FaceTracker:
             with_reid=False,
         )
 
-    def set_gallery(self, feats: Optional[np.ndarray], labels: List[str]) -> None:
-        """Update gallery embeddings and labels."""
+    def set_gallery(
+        self,
+        feats: Optional[np.ndarray],
+        labels: List[str],
+        uuids: Optional[List[str]] = None,
+    ) -> None:
+        """Update gallery centroids, names, and UUIDs (called after enrollment).
+
+        ``uuids`` is optional for back-compat — if omitted, an empty string is
+        used as a placeholder per row. Pass real UUIDs when using
+        ``UUIDGallery.get_centroids()`` so downstream layers can reference
+        identities by stable ID.
+
+        Two side-effects on cached track identities (``self._identities``):
+
+        1. **Stale invalidation** — if a track's cached UUID no longer exists
+           in the new gallery (it got deleted), reset that track to "new"
+           status so it re-enters recognition on the next frame. Without this,
+           a track identified as "sean" before sean got deleted would keep
+           displaying "sean" until the BoTSORT track itself died.
+
+        2. **Name propagation** — if a track's cached UUID still exists but
+           its name was changed (e.g. anon_xxx → sean via /set_name), update
+           the cached ``ident.name`` in place. Without this, the displayed
+           label would lag the rename by up to ``re_identify_interval`` seconds
+           (the next recognition cycle), confusing demo viewers who expect
+           rename to update the video immediately.
+        """
         self._gal_feats = feats
         self._gal_labels = list(labels)
+        if uuids is None:
+            self._gal_uuids = [""] * len(labels)
+        else:
+            if len(uuids) != len(labels):
+                raise ValueError(
+                    f"uuids ({len(uuids)}) and labels ({len(labels)}) must be same length"
+                )
+            self._gal_uuids = list(uuids)
+
+        # Build uuid → current_name map for O(1) lookups
+        valid_uuids: Dict[str, str] = {}
+        for u, n in zip(self._gal_uuids, self._gal_labels):
+            if u:
+                valid_uuids[u] = n
+
+        stale_count = 0
+        renamed_count = 0
+        for tid, ident in self._identities.items():
+            if not ident.uuid:
+                continue
+            if ident.uuid not in valid_uuids:
+                # (1) Stale: the UUID this track was identified to is gone.
+                log.info(
+                    "Track %d: identity %r (uuid=%s) removed from gallery — resetting",
+                    tid,
+                    ident.name,
+                    ident.uuid,
+                )
+                ident.status = "new"
+                ident.name = None
+                ident.uuid = None
+                ident.sim = 0.0
+                ident.tier = sl.TIER_UNCERTAIN
+                ident.vote_names.clear()
+                ident.vote_uuids.clear()
+                ident.vote_tiers.clear()
+                ident.vote_sims.clear()
+                ident.embeddings.clear()
+                ident.recog_attempts = 0
+                # Don't reset first_seen / frames_seen / unknown_since —
+                # those describe the track itself, not the identity.
+                stale_count += 1
+            else:
+                # (2) UUID still valid — check if name changed (rename via
+                # /set_name, or claim via /selfie merging anon into named).
+                new_name = valid_uuids[ident.uuid]
+                # ident.name might be None for tracks that were anon (no name
+                # finalized yet); coerce both sides to plain strings for
+                # comparison. "" (anon) → "" (still anon) is a no-op;
+                # "" → "sean" is the rename / claim case.
+                cached_name = ident.name or ""
+                if cached_name != new_name:
+                    log.info(
+                        "Track %d: uuid=%s name updated %r → %r (live propagation)",
+                        tid,
+                        ident.uuid,
+                        cached_name,
+                        new_name,
+                    )
+                    # Update cached name AND any votes for this UUID so the
+                    # display rebuild picks up the change immediately. Note:
+                    # we do NOT touch sim / tier / status — only the name.
+                    ident.name = new_name if new_name else None
+                    for i, vu in enumerate(ident.vote_uuids):
+                        if vu == ident.uuid:
+                            ident.vote_names[i] = new_name
+                    renamed_count += 1
+        if stale_count > 0 or renamed_count > 0:
+            log.info(
+                "set_gallery: reset=%d renamed=%d (%d valid UUIDs)",
+                stale_count,
+                renamed_count,
+                len(valid_uuids),
+            )
+
+    def set_thresholds(
+        self,
+        *,
+        sim_thr: Optional[float] = None,
+        strict_margin: Optional[float] = None,
+        loose_margin: Optional[float] = None,
+    ) -> None:
+        """Hot-update recognition thresholds. ``None`` means "leave as-is"."""
+        if sim_thr is not None:
+            self.sim_thr = float(sim_thr)
+        if strict_margin is not None:
+            self.strict_margin = float(strict_margin)
+        if loose_margin is not None:
+            self.loose_margin = float(loose_margin)
 
     def set_sim_thr(self, thr: float) -> None:
-        """Update similarity threshold at runtime."""
+        """Back-compat shim — prefer ``set_thresholds(sim_thr=thr)``."""
         self.sim_thr = float(thr)
+
+    # ------------------------------------------------------------------
+    # Main per-frame entry point
+    # ------------------------------------------------------------------
 
     def update(
         self,
@@ -178,12 +422,12 @@ class FaceTracker:
         dets : ndarray (N, 5)
             SCRFD detections [x1, y1, x2, y2, conf].
         kpss : ndarray (N, 5, 2) or None
-            5-point landmarks per detection.
+            5-point landmarks per detection (used for alignment).
 
         Returns
         -------
         list[TrackResult]
-            One entry per tracked face.
+            One entry per active track this frame.
         """
         now = time.time()
         H, W = frame.shape[:2]
@@ -191,10 +435,10 @@ class FaceTracker:
         # Run BoTSORT
         tracks = self._run_tracker(dets, frame)
 
-        # Match tracks to SCRFD detections (for landmarks)
+        # Match tracks back to SCRFD detections (for landmarks)
         track_det_map = self._match_tracks_to_dets(tracks, dets, kpss)
 
-        # Build results + collect tracks needing recognition
+        # Build results + collect tracks that still need recognition
         self._active_ids = set()
         results: List[TrackResult] = []
         need_recog: List[Tuple[int, np.ndarray, Optional[np.ndarray]]] = []
@@ -220,49 +464,25 @@ class FaceTracker:
             ident = self._identities[track_id]
             ident.frames_seen += 1
 
-            # Track how long this face has been unknown
-            if ident.status == "identified":
-                ident.unknown_since = 0.0  # reset when identified
+            # Track how long this face has been unknown (for auto-enroll later)
+            if ident.status == "identified" and ident.tier == sl.TIER_CONFIDENT:
+                ident.unknown_since = 0.0
             elif ident.unknown_since == 0.0:
-                ident.unknown_since = now  # start timing
+                ident.unknown_since = now
 
-            # Re-identify: if "unknown" or low-confidence "identified" and enough
-            # time has passed, reset voting state so recognition retries.
-            # Handles the "walking closer" scenario where face gets clearer over time.
-            if (
-                self.re_identify_interval > 0
-                and (now - ident.last_recog_time) >= self.re_identify_interval
-            ):
-                if ident.status == "unknown":
-                    log.debug(
-                        "Track %d: re-identify (was unknown, %.1fs since last attempt)",
-                        track_id,
-                        now - ident.last_recog_time,
-                    )
-                    ident.status = "new"
-                    ident.vote_names.clear()
-                    ident.vote_sims.clear()
-                    ident.embeddings.clear()
-                    ident.recog_attempts = 0
-                elif ident.status == "identified" and ident.sim < self.sim_thr + 0.1:
-                    # Low-confidence match — re-verify when face is clearer
-                    log.debug(
-                        "Track %d: re-verify '%s' (sim=%.3f, marginal)",
-                        track_id,
-                        ident.name,
-                        ident.sim,
-                    )
-                    ident.status = "new"
-                    ident.vote_names.clear()
-                    ident.vote_sims.clear()
-                    ident.embeddings.clear()
-                    ident.recog_attempts = 0
+            # Re-identify policy: if state is stale, reset votes so recognition
+            # retries on what is hopefully a clearer frame.
+            self._maybe_reset_for_reidentify(ident, now)
 
-            # Should we run recognition for this track?
+            # Decide whether this track needs another recognition attempt.
+            # NOTE: we intentionally do NOT require a non-empty gallery here.
+            # Even with zero identities, we still want to embed the face and
+            # forward it to AutoEnroller (the empty-gallery branch below sets
+            # tier=uncertain and calls _fire_unknown_callback). Excluding empty
+            # gallery here would silently break auto-enrollment on a fresh
+            # install.
             needs_recog = (
                 ident.status in ("new", "identifying")
-                and self._gal_feats is not None
-                and self._gal_feats.size > 0
                 and (now - ident.last_recog_time) >= self.recog_interval
                 and ident.recog_attempts < self.max_recog_attempts
             )
@@ -271,79 +491,257 @@ class FaceTracker:
                 det_kps = track_det_map.get(track_id, {}).get("kps")
                 need_recog.append((track_id, np.array([x1, y1, x2, y2]), det_kps))
 
-            # Build display name based on current status
-            name_display, is_known, sim = self._get_display_name(ident)
+            # Build display + raw name based on current status/tier
+            raw_name, display_name, is_known, sim, tier, uuid = self._build_display(
+                ident
+            )
 
             results.append(
                 TrackResult(
                     track_id=track_id,
                     bbox=(x1, y1, x2, y2),
                     conf=conf,
-                    name=name_display,
+                    raw_name=raw_name,
+                    name=display_name,
                     sim=sim,
+                    tier=tier,
+                    uuid=uuid,
                     is_known=is_known,
                 )
             )
 
-        # Batch recognition
+        # Batched recognition for tracks queued this frame
         if need_recog and self.arc is not None:
-            log.debug(f"Running recognition for {len(need_recog)} tracks")
+            log.debug("Running recognition for %d tracks", len(need_recog))
             self._run_recognition_batch(frame, need_recog, now)
         elif need_recog:
-            log.warning(f"need_recog={len(need_recog)} but arc is None")
+            log.warning("need_recog=%d but arc is None", len(need_recog))
 
-        # Cleanup stale tracks
+        # Cleanup tracks that BoTSORT stopped reporting
         self._cleanup_stale()
 
-        # Build faces sorted by bbox area (largest = closest first)
+        # Build the by-area sorted face list used by /who and unknown capture
+        self._current_faces = self._build_current_faces(results)
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Re-identify / display
+    # ------------------------------------------------------------------
+
+    def _maybe_reset_for_reidentify(self, ident: _TrackIdentity, now: float) -> None:
+        """Reset votes if it's been a while since last recognition attempt.
+
+        Two trigger cases:
+          - status == "unknown": maybe the face has gotten clearer since.
+          - status == "identified" but tier == "tentative" or sim is marginal:
+            try to upgrade to "confident" when conditions improve.
+
+        Interaction with AutoEnroller
+        -----------------------------
+        While ``status == "unknown"`` (between finalize and re-identify
+        firing), no recognition runs for this track, so AutoEnroller stops
+        receiving observe() calls. This is acceptable: AutoEnroller's buffer
+        from before finalization is still valid (samples don't age inside
+        the buffer), and re-identify will resume observations within
+        ``re_identify_interval`` seconds (default 3s) — well before
+        AutoEnroller's ``stale_track_sec`` (default 5s) would GC the buffer.
+        """
+        if self.re_identify_interval <= 0:
+            return
+        if (now - ident.last_recog_time) < self.re_identify_interval:
+            return
+
+        should_reset = False
+        if ident.status == "unknown":
+            should_reset = True
+            log.debug(
+                "Track %d: re-identify (was unknown, %.1fs since last attempt)",
+                ident.track_id,
+                now - ident.last_recog_time,
+            )
+        elif ident.status == "identified" and ident.tier == sl.TIER_TENTATIVE:
+            should_reset = True
+            log.debug(
+                "Track %d: re-verify '%s' (tentative, sim=%.3f)",
+                ident.track_id,
+                ident.name,
+                ident.sim,
+            )
+        elif ident.status == "identified" and ident.sim < self.sim_thr + 0.1:
+            # Confident but marginal sim — re-verify when face gets clearer.
+            should_reset = True
+            log.debug(
+                "Track %d: re-verify '%s' (marginal sim=%.3f)",
+                ident.track_id,
+                ident.name,
+                ident.sim,
+            )
+
+        if should_reset:
+            ident.status = "new"
+            ident.vote_names.clear()
+            ident.vote_uuids.clear()
+            ident.vote_tiers.clear()
+            ident.vote_sims.clear()
+            ident.embeddings.clear()
+            ident.recog_attempts = 0
+
+    @staticmethod
+    def _anon_label(uuid: Optional[str]) -> str:
+        """Short, stable, human-readable label for an anonymous (un-named) UUID.
+
+        Example: '73d0a41a63aa4594...' → 'anon_73d0a4'
+
+        The 6 hex chars give ~16.7M possible labels — collision-free for any
+        realistic gallery size. The label is deterministic: same UUID always
+        maps to the same label, even across restarts. The LLM can recognize
+        this as "we've met but I don't know your name yet" and prompt for one.
+        """
+        if not uuid:
+            return "unknown"
+        return f"anon_{uuid[:6]}"
+
+    def _build_display(
+        self, ident: _TrackIdentity
+    ) -> Tuple[Optional[str], Optional[str], bool, float, str, Optional[str]]:
+        """Return ``(raw_name, display_name, is_known, sim, tier, uuid)``.
+
+        ``raw_name`` is the plain label for downstream consumers (no score).
+        ``display_name`` is the formatted string for on-frame drawing.
+        ``is_known`` is True only when tier is confident.
+        ``uuid`` is the gallery UUID for stable identity references (None
+        when no identification has been made yet).
+        """
+        # Confident identification with a name
+        if (
+            ident.status == "identified"
+            and ident.tier == sl.TIER_CONFIDENT
+            and ident.name
+        ):
+            return (
+                ident.name,
+                f"{ident.name} ({ident.sim:.2f})",
+                True,
+                ident.sim,
+                sl.TIER_CONFIDENT,
+                ident.uuid,
+            )
+
+        # Confident identification but the UUID has no name yet (auto-enrolled,
+        # awaiting /set_name). Surface a stable short label so the LLM and
+        # operator can distinguish "we've met before" from "complete stranger".
+        if (
+            ident.status == "identified"
+            and ident.tier == sl.TIER_CONFIDENT
+            and not ident.name
+            and ident.uuid
+        ):
+            label = self._anon_label(ident.uuid)
+            return (
+                label,
+                f"{label} ({ident.sim:.2f})",
+                True,
+                ident.sim,
+                sl.TIER_CONFIDENT,
+                ident.uuid,
+            )
+
+        # Tentative identification with a name — show with "?" suffix
+        if (
+            ident.status == "identified"
+            and ident.tier == sl.TIER_TENTATIVE
+            and ident.name
+        ):
+            return (
+                ident.name,
+                f"{ident.name}? ({ident.sim:.2f})",
+                False,
+                ident.sim,
+                sl.TIER_TENTATIVE,
+                ident.uuid,
+            )
+
+        # Tentative identification for an anonymous UUID (matched something
+        # in gallery but with shaky confidence, and that UUID has no name).
+        if (
+            ident.status == "identified"
+            and ident.tier == sl.TIER_TENTATIVE
+            and not ident.name
+            and ident.uuid
+        ):
+            label = self._anon_label(ident.uuid)
+            return (
+                label,
+                f"{label}? ({ident.sim:.2f})",
+                False,
+                ident.sim,
+                sl.TIER_TENTATIVE,
+                ident.uuid,
+            )
+
+        # Voting still in progress — surface a tentative best guess if we have one
+        if ident.status == "identifying" and ident.vote_names:
+            real = [
+                (n, u, s)
+                for n, u, t, s in zip(
+                    ident.vote_names,
+                    ident.vote_uuids,
+                    ident.vote_tiers,
+                    ident.vote_sims,
+                )
+                if n != "unknown"
+            ]
+            if real:
+                top_name = max(
+                    {n for n, _, _ in real},
+                    key=lambda x: sum(1 for n, _, _ in real if n == x),
+                )
+                top_sim = max(s for n, _, s in real if n == top_name)
+                # Best-guess UUID = most-frequent UUID among votes for top_name
+                cand_uuids = [u for n, u, _ in real if n == top_name and u is not None]
+                top_uuid = (
+                    Counter(cand_uuids).most_common(1)[0][0] if cand_uuids else None
+                )
+                # Anonymous UUID (no name yet) → use stable short label
+                display_label = top_name if top_name else self._anon_label(top_uuid)
+                return (
+                    display_label,
+                    f"{display_label}? ({top_sim:.2f})",
+                    False,
+                    top_sim,
+                    sl.TIER_TENTATIVE,
+                    top_uuid,
+                )
+
+        # New or unknown — no identity available
+        return (None, "unknown", False, 0.0, sl.TIER_UNCERTAIN, None)
+
+    def _build_current_faces(self, results: List[TrackResult]) -> list:
+        """Sort the per-track results into a by-area face list.
+
+        Used by /who and the auto-enroll candidate selector. "Largest face"
+        is a cheap proxy for "closest to camera = most likely the addressee".
+        """
         faces = []
         for r in results:
             x1, y1, x2, y2 = r.bbox
             area = (x2 - x1) * (y2 - y1)
-            ident = self._identities.get(r.track_id)
-            name = ident.name if ident and ident.status == "identified" else "unknown"
             faces.append(
                 {
-                    "name": name,
+                    "name": r.raw_name if r.raw_name else "unknown",
+                    "uuid": r.uuid,
+                    "tier": r.tier,
                     "bbox": r.bbox,
                     "area": area,
                     "track_id": r.track_id,
                 }
             )
-        self._current_faces = sorted(faces, key=lambda f: f["area"], reverse=True)
+        return sorted(faces, key=lambda f: f["area"], reverse=True)
 
-        return results
-
-    def _get_display_name(
-        self, ident: _TrackIdentity
-    ) -> Tuple[Optional[str], bool, float]:
-        """Get display name for a track based on its identity status.
-
-        Returns (name_display, is_known, sim).
-        """
-        if ident.status == "identified" and ident.name:
-            # Confirmed identity
-            return f"{ident.name} ({ident.sim:.2f})", True, ident.sim
-
-        elif ident.status == "identifying" and ident.vote_names:
-            # Voting in progress — show temporary best guess with "?"
-            real = [n for n in ident.vote_names if n != "__unknown__"]
-            if real:
-                top_name = max(set(real), key=real.count)
-                top_sim = max(
-                    s
-                    for n, s in zip(ident.vote_names, ident.vote_sims)
-                    if n == top_name
-                )
-                return f"{top_name}? ({top_sim:.2f})", False, top_sim
-            return "unknown", False, 0.0
-
-        elif ident.status == "unknown":
-            return "unknown", False, 0.0
-
-        else:
-            # New track, no recognition yet
-            return "unknown", False, 0.0
+    # ------------------------------------------------------------------
+    # BoTSORT plumbing
+    # ------------------------------------------------------------------
 
     def _run_tracker(self, dets: np.ndarray, frame: np.ndarray) -> np.ndarray:
         """Run BoTSORT. Returns (M, 7) [x1,y1,x2,y2,track_id,conf,cls]."""
@@ -367,9 +765,9 @@ class FaceTracker:
     ) -> Dict[int, dict]:
         """Match tracked boxes back to SCRFD detections to recover landmarks.
 
-        Returns {track_id: {"det_idx": int, "kps": ndarray(5,2) or None}}
+        Returns ``{track_id: {"det_idx": int, "kps": ndarray(5,2) or None}}``.
         """
-        result = {}
+        result: Dict[int, dict] = {}
         if tracks is None or len(tracks) == 0 or dets is None or len(dets) == 0:
             return result
 
@@ -397,7 +795,7 @@ class FaceTracker:
                     best_d = d_idx
 
             if best_d >= 0 and best_iou > 0.3:
-                entry: dict[str, object] = {"det_idx": best_d}
+                entry: dict = {"det_idx": best_d}
                 entry["kps"] = (
                     kpss[best_d] if kpss is not None and best_d < len(kpss) else None
                 )
@@ -405,7 +803,9 @@ class FaceTracker:
 
         return result
 
+    # ------------------------------------------------------------------
     # Recognition
+    # ------------------------------------------------------------------
 
     def _run_recognition_batch(
         self,
@@ -413,7 +813,7 @@ class FaceTracker:
         need_recog: List[Tuple[int, np.ndarray, Optional[np.ndarray]]],
         now: float,
     ) -> None:
-        """Run AdaFace on unidentified tracks and update votes."""
+        """Embed unidentified tracks in one TRT call and update their votes."""
         from .adaface import warp_face_by_5p
 
         crops: List[np.ndarray] = []
@@ -439,7 +839,7 @@ class FaceTracker:
         if not crops:
             return
 
-        # Batch inference
+        # Batched AdaFace inference
         all_feats = []
         for i in range(0, len(crops), self.arc_max_bs):
             batch = crops[i : i + self.arc_max_bs]
@@ -452,13 +852,38 @@ class FaceTracker:
             np.concatenate(all_feats, axis=0) if len(all_feats) > 1 else all_feats[0]
         )
 
-        # Match against gallery
         if self._gal_feats is None or self._gal_feats.size == 0:
+            # Even with empty gallery, we want to give the auto-enroller a
+            # chance to observe (everyone is "uncertain" in this state, but
+            # we still need the embedding-buffering path to fire).
+            for idx, track_id in enumerate(crop_track_ids):
+                ident = self._identities.get(track_id)
+                if ident is None:
+                    continue
+                ident.last_recog_time = now
+                ident.recog_attempts += 1
+                ident.status = "identifying"
+                ident.embeddings.append(feats[idx])
+                ident.vote_names.append("unknown")
+                ident.vote_uuids.append(None)
+                ident.vote_tiers.append(sl.TIER_UNCERTAIN)
+                ident.vote_sims.append(0.0)
+                self._fire_unknown_callback(
+                    track_id,
+                    crops[idx],
+                    feats[idx],
+                    tuple(crop_bboxes[idx]),
+                    sl.TIER_UNCERTAIN,
+                )
+                if (
+                    len(ident.vote_names) >= self.vote_frames
+                    or ident.recog_attempts >= self.max_recog_attempts
+                ):
+                    self._finalize_identity(ident)
             return
 
+        # Single matmul vs. gallery centroids: (B, dim) @ (dim, N_id) = (B, N_id)
         S = feats @ self._gal_feats.T
-        best_j = np.argmax(S, axis=1)
-        best_v = S[np.arange(S.shape[0]), best_j]
 
         for idx, track_id in enumerate(crop_track_ids):
             ident = self._identities.get(track_id)
@@ -469,90 +894,223 @@ class FaceTracker:
             ident.recog_attempts += 1
             ident.status = "identifying"
 
-            sim_val = float(best_v[idx])
-            label_idx = int(best_j[idx])
+            name, tier, s1, s2 = sl.recognize_from_sims(
+                S[idx],
+                self._gal_labels,
+                min_sim=self.sim_thr,
+                strict_margin=self.strict_margin,
+                loose_margin=self.loose_margin,
+            )
+
+            # Map name → UUID using the top-1 row of S. recognize_from_sims
+            # returns the name of the best-scoring row; for tier "uncertain"
+            # the name is "unknown" so there's no UUID to attach.
+            if name != "unknown" and self._gal_uuids:
+                top_idx = int(np.argmax(S[idx]))
+                vote_uuid: Optional[str] = self._gal_uuids[top_idx]
+            else:
+                vote_uuid = None
 
             ident.embeddings.append(feats[idx])
+            ident.vote_names.append(name)
+            ident.vote_uuids.append(vote_uuid)
+            ident.vote_tiers.append(tier)
+            ident.vote_sims.append(s1)
 
             log.debug(
-                f"Track {ident.track_id} bbox={crop_bboxes[idx][:4]}: sim={sim_val:.3f} best='{self._gal_labels[label_idx]}' → "
-                f"{'MATCH' if sim_val >= self.sim_thr else 'NO MATCH'}"
+                "Track %d bbox=%s: top1=%s/%.3f top2=%.3f margin=%.3f → tier=%s uuid=%s",
+                track_id,
+                tuple(crop_bboxes[idx]),
+                name,
+                s1,
+                s2,
+                s1 - s2,
+                tier,
+                vote_uuid[:8] + "..." if vote_uuid else "-",
             )
-            if sim_val >= self.sim_thr:
-                ident.vote_names.append(self._gal_labels[label_idx])
-                ident.vote_sims.append(sim_val)
-            else:
-                ident.vote_names.append("__unknown__")
-                ident.vote_sims.append(sim_val)
 
-            # Check if ready to decide
+            # Notify auto-enroller (it decides what to do based on tier)
+            self._fire_unknown_callback(
+                track_id,
+                crops[idx],
+                feats[idx],
+                tuple(crop_bboxes[idx]),
+                tier,
+            )
+
+            # Decide as soon as we have enough votes or hit the cap
             if (
                 len(ident.vote_names) >= self.vote_frames
                 or ident.recog_attempts >= self.max_recog_attempts
             ):
                 self._finalize_identity(ident)
 
+    def _fire_unknown_callback(
+        self,
+        track_id: int,
+        crop: np.ndarray,
+        embedding: np.ndarray,
+        bbox: Tuple[int, int, int, int],
+        tier: str,
+    ) -> None:
+        """Forward a recognition observation to the auto-enroll callback.
+
+        The callback receives every tier (not just uncertain) — AutoEnroller
+        uses non-uncertain observations to clear its per-track buffer when a
+        formerly-unknown face becomes identified.
+        """
+        if self.on_unknown_sample is None:
+            return
+        try:
+            self.on_unknown_sample(track_id, crop, embedding, bbox, tier)
+        except Exception as e:
+            log.warning("on_unknown_sample callback raised: %s", e)
+
     def _finalize_identity(self, ident: _TrackIdentity) -> None:
-        """Decide identity from collected votes using majority voting."""
+        """Decide a track's identity from collected (name, tier) votes.
+
+        Strategy:
+          - Tally CONFIDENT votes by name.
+          - Tally TENTATIVE votes by name (these EXCLUDE confident; they're a
+            separate weaker bucket).
+          - If any name's confident-fraction >= vote_threshold → identified
+            confident.
+          - Else if any name's (confident + tentative)-fraction >= threshold
+            → identified tentative.
+          - Else → unknown.
+
+        This means a track with mixed evidence (some confident, some tentative
+        for the same name) is preferentially called confident — confident
+        votes are strictly stronger than tentative ones.
+        """
         now = time.time()
-
-        if not ident.vote_names:
-            ident.status = "unknown"
-            ident.name = None
-            if ident.unknown_since == 0:
-                ident.unknown_since = now
-            return
-
-        real_votes = [n for n in ident.vote_names if n != "__unknown__"]
-
-        if not real_votes:
-            ident.status = "unknown"
-            ident.name = None
-            if ident.unknown_since == 0:
-                ident.unknown_since = now
-            log.debug(f"Track {ident.track_id}: all votes unknown")
-            return
-
-        counter = Counter(real_votes)
-        best_name, best_count = counter.most_common(1)[0]
         total_votes = len(ident.vote_names)
-        ratio = best_count / total_votes
 
-        if ratio >= self.vote_threshold:
-            winning_sims = [
-                s for n, s in zip(ident.vote_names, ident.vote_sims) if n == best_name
-            ]
-            avg_sim = sum(winning_sims) / len(winning_sims) if winning_sims else 0.0
+        if total_votes == 0:
+            self._set_unknown(ident, now, reason="no_votes")
+            return
 
-            ident.status = "identified"
-            ident.name = best_name
-            ident.sim = avg_sim
-            ident.unknown_since = 0  # no longer unknown
-            log.info(
-                f"Track {ident.track_id}: confirmed '{best_name}' "
-                f"(votes={best_count}/{total_votes}, sim={avg_sim:.3f})"
-            )
-        else:
-            ident.status = "unknown"
-            ident.name = None
-            if ident.unknown_since == 0:
-                ident.unknown_since = now
-            log.debug(
-                f"Track {ident.track_id}: no majority ({best_name} {best_count}/{total_votes})"
-            )
+        confident_counts: Counter = Counter()
+        loose_counts: Counter = Counter()  # confident + tentative for each name
+        for name, tier in zip(ident.vote_names, ident.vote_tiers):
+            if name == "unknown":
+                continue
+            if tier == sl.TIER_CONFIDENT:
+                confident_counts[name] += 1
+                loose_counts[name] += 1
+            elif tier == sl.TIER_TENTATIVE:
+                loose_counts[name] += 1
+            # tier == "uncertain" never carries a real name (name == "unknown")
+
+        # Try confident first
+        if confident_counts:
+            best_name, best_count = confident_counts.most_common(1)[0]
+            if best_count / total_votes >= self.vote_threshold:
+                self._set_identified(
+                    ident,
+                    best_name,
+                    sl.TIER_CONFIDENT,
+                    now,
+                    votes_for_name=best_count,
+                    total_votes=total_votes,
+                )
+                return
+
+        # Fall back to tentative (still requires the same vote_threshold of
+        # loose evidence — we just don't demand confident-tier evidence)
+        if loose_counts:
+            best_name, best_count = loose_counts.most_common(1)[0]
+            if best_count / total_votes >= self.vote_threshold:
+                self._set_identified(
+                    ident,
+                    best_name,
+                    sl.TIER_TENTATIVE,
+                    now,
+                    votes_for_name=best_count,
+                    total_votes=total_votes,
+                )
+                return
+
+        self._set_unknown(ident, now, reason="no_majority")
+
+    def _set_identified(
+        self,
+        ident: _TrackIdentity,
+        name: str,
+        tier: str,
+        now: float,
+        *,
+        votes_for_name: int,
+        total_votes: int,
+    ) -> None:
+        """Apply an identified decision to a track and log it."""
+        winning_sims = [
+            s for n, s in zip(ident.vote_names, ident.vote_sims) if n == name
+        ]
+        avg_sim = sum(winning_sims) / len(winning_sims) if winning_sims else 0.0
+
+        # Pick the UUID associated with the winning name. Most-frequent UUID
+        # among the votes that voted for `name` — robust to the rare case
+        # where the same name maps to two distinct UUIDs over the vote window
+        # (e.g. two enrollments of the same person; both centroids matched at
+        # different votes).
+        winning_uuids = [
+            u
+            for n, u in zip(ident.vote_names, ident.vote_uuids)
+            if n == name and u is not None
+        ]
+        winning_uuid: Optional[str] = None
+        if winning_uuids:
+            winning_uuid = Counter(winning_uuids).most_common(1)[0][0]
+
+        ident.status = "identified"
+        ident.tier = tier
+        ident.name = name
+        ident.uuid = winning_uuid
+        ident.sim = avg_sim
+        ident.unknown_since = (
+            0.0 if tier == sl.TIER_CONFIDENT else (ident.unknown_since or now)
+        )
+
+        log.info(
+            "Track %d: %s '%s' uuid=%s (votes=%d/%d, sim=%.3f)",
+            ident.track_id,
+            tier,
+            name,
+            (winning_uuid[:8] + "...") if winning_uuid else "-",
+            votes_for_name,
+            total_votes,
+            avg_sim,
+        )
+
+    def _set_unknown(self, ident: _TrackIdentity, now: float, *, reason: str) -> None:
+        """Mark a track as unknown (no majority found)."""
+        ident.status = "unknown"
+        ident.tier = sl.TIER_UNCERTAIN
+        ident.name = None
+        ident.uuid = None
+        if ident.unknown_since == 0:
+            ident.unknown_since = now
+        log.debug("Track %d: unknown (%s)", ident.track_id, reason)
+
+    # ------------------------------------------------------------------
+    # Cleanup / introspection
+    # ------------------------------------------------------------------
 
     def _cleanup_stale(self) -> None:
-        """Remove identity entries for tracks no longer active."""
+        """Drop identity state for tracks BoTSORT no longer reports."""
         stale = [tid for tid in self._identities if tid not in self._active_ids]
         for tid in stale:
             del self._identities[tid]
 
     def get_track_identities(self) -> Dict[int, dict]:
-        """Get current identity state for all active tracks."""
+        """Snapshot of current identity state per active track (for /who etc)."""
         return {
             tid: {
                 "name": ident.name,
+                "uuid": ident.uuid,
                 "status": ident.status,
+                "tier": ident.tier,
                 "sim": ident.sim,
                 "frames_seen": ident.frames_seen,
                 "recog_attempts": ident.recog_attempts,
@@ -563,28 +1121,18 @@ class FaceTracker:
         }
 
     def get_faces(self) -> list:
-        """Get all faces sorted by bbox area (largest first).
+        """All faces in the current frame, sorted by bbox area descending.
 
-        Returns
-        -------
-        list of dict
-            Each dict has 'name', 'bbox', 'area', 'track_id'.
-            Empty list if no faces in current frame.
+        Each entry: ``{name, tier, bbox, area, track_id}``.
+        ``name`` is ``"unknown"`` if the track has no identification (or is
+        only tentative — callers check ``tier`` separately).
         """
         return self._current_faces
 
     def get_unknowns(self) -> list:
-        """Get all unknown faces in current frame with duration info.
-
-        Returns
-        -------
-        list of dict
-            Each dict has 'track_id', 'bbox', 'area', 'unknown_duration'.
-            Empty list if no unknowns.
-        """
+        """Faces currently unidentified, with how long they've been unknown."""
         now = time.time()
         unknowns = []
-
         for face in self._current_faces:
             if face["name"] != "unknown":
                 continue
@@ -592,7 +1140,6 @@ class FaceTracker:
             ident = self._identities.get(tid)
             if ident is None or ident.unknown_since <= 0:
                 continue
-
             unknowns.append(
                 {
                     "track_id": tid,
@@ -601,11 +1148,10 @@ class FaceTracker:
                     "unknown_duration": round(now - ident.unknown_since, 1),
                 }
             )
-
         return unknowns
 
     def reset(self) -> None:
-        """Reset all tracking state."""
+        """Reset all tracking state (e.g. after gallery wipe between venues)."""
         self._identities.clear()
         self._active_ids.clear()
         self._current_faces.clear()

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -149,6 +149,13 @@ class _TrackIdentity:
     # None until the first confident identification.
     session_last_seen_iso: Optional[str] = None
 
+    # The last UUID this track was CONFIDENTLY identified as. Persists across
+    # re-identify resets (unlike `uuid`, which gets cleared when a track goes
+    # unknown), so we can detect when one continuous track flips from one
+    # confident identity to a different one — the trigger for auto-merging
+    # fragmented identities (e.g. a frontal vs a profile enrollment).
+    last_confident_uuid: Optional[str] = None
+
 
 # ---------------------------------------------------------------------------
 # FaceTracker
@@ -243,6 +250,11 @@ class FaceTracker:
         # Used by SampleRefreshManager for continuous-learning sample
         # enrichment. Guard A (sim threshold) is the caller's responsibility.
         self.on_confident_sample = on_confident_sample
+        # Fired when one continuous track's CONFIDENT identity changes from one
+        # UUID to a different one. Signature: (track_id, old_uuid, new_uuid).
+        # Set as a plain attribute (like on_unknown_sample) by run.py, wired to
+        # the auto-merge handler. None = feature off.
+        self.on_identity_flip = None
 
         # Gallery (set via set_gallery). All three arrays are parallel —
         # row i of _gal_feats has name _gal_labels[i] and UUID _gal_uuids[i].
@@ -345,6 +357,14 @@ class FaceTracker:
         stale_count = 0
         renamed_count = 0
         for tid, ident in self._identities.items():
+            # A confidently-remembered UUID that no longer exists (e.g. it was
+            # the loser of an auto-merge) must be forgotten, else it could
+            # spuriously re-trigger a flip. Do this regardless of current uuid.
+            if (
+                ident.last_confident_uuid
+                and ident.last_confident_uuid not in valid_uuids
+            ):
+                ident.last_confident_uuid = None
             if not ident.uuid:
                 continue
             if ident.uuid not in valid_uuids:
@@ -459,7 +479,7 @@ class FaceTracker:
         # Build results + collect tracks that still need recognition
         self._active_ids = set()
         results: List[TrackResult] = []
-        need_recog: List[Tuple[int, np.ndarray, Optional[np.ndarray]]] = []
+        need_recog: List[Tuple[int, np.ndarray, Optional[np.ndarray], float]] = []
 
         for track in tracks:
             x1, y1, x2, y2 = map(int, track[:4])
@@ -507,7 +527,7 @@ class FaceTracker:
 
             if needs_recog:
                 det_kps = track_det_map.get(track_id, {}).get("kps")
-                need_recog.append((track_id, np.array([x1, y1, x2, y2]), det_kps))
+                need_recog.append((track_id, np.array([x1, y1, x2, y2]), det_kps, conf))
 
             # Build display + raw name based on current status/tier
             raw_name, display_name, is_known, sim, tier, uuid = self._build_display(
@@ -843,8 +863,10 @@ class FaceTracker:
         crops: List[np.ndarray] = []
         crop_track_ids: List[int] = []
         crop_bboxes: List[np.ndarray] = []
+        crop_kpss: List[Optional[np.ndarray]] = []
+        crop_confs: List[float] = []
 
-        for track_id, bbox, kps in need_recog:
+        for track_id, bbox, kps, conf in need_recog:
             try:
                 x1, y1, x2, y2 = bbox
                 if kps is not None:
@@ -857,6 +879,8 @@ class FaceTracker:
                 crops.append(crop)
                 crop_track_ids.append(track_id)
                 crop_bboxes.append(bbox)
+                crop_kpss.append(kps)
+                crop_confs.append(conf)
             except Exception:
                 continue
 
@@ -960,6 +984,8 @@ class FaceTracker:
                 feats[idx],
                 tuple(crop_bboxes[idx]),
                 tier,
+                crop_kpss[idx],
+                crop_confs[idx],
             )
 
             # Notify refresh manager on confident identifications. Refresh
@@ -999,6 +1025,8 @@ class FaceTracker:
         embedding: np.ndarray,
         bbox: Tuple[int, int, int, int],
         tier: str,
+        kps: Optional[np.ndarray] = None,
+        conf: float = 1.0,
     ) -> None:
         """Forward a recognition observation to the auto-enroll callback.
 
@@ -1009,7 +1037,7 @@ class FaceTracker:
         if self.on_unknown_sample is None:
             return
         try:
-            self.on_unknown_sample(track_id, crop, embedding, bbox, tier)
+            self.on_unknown_sample(track_id, crop, embedding, bbox, tier, kps, conf)
         except Exception as e:
             log.warning("on_unknown_sample callback raised: %s", e)
 
@@ -1118,6 +1146,21 @@ class FaceTracker:
         ident.unknown_since = (
             0.0 if tier == sl.TIER_CONFIDENT else (ident.unknown_since or now)
         )
+
+        # --- identity-flip detection (auto-merge trigger) ---
+        # If this same continuous track was previously CONFIDENT on a
+        # different UUID, the two UUIDs are very likely the same person whose
+        # poses got separate enrollments (frontal vs profile). Fire the flip
+        # callback so the outer layer can merge them. Only confident->confident
+        # transitions count; we reuse the tier already decided above.
+        if tier == sl.TIER_CONFIDENT and winning_uuid:
+            prev = ident.last_confident_uuid
+            if prev and prev != winning_uuid and self.on_identity_flip is not None:
+                try:
+                    self.on_identity_flip(ident.track_id, prev, winning_uuid)
+                except Exception as e:
+                    log.warning("on_identity_flip callback raised: %s", e)
+            ident.last_confident_uuid = winning_uuid
 
         log.info(
             "Track %d: %s '%s' uuid=%s (votes=%d/%d, sim=%.3f)",

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -224,7 +224,7 @@ class FaceTracker:
         det_conf: float = 0.5,
         re_identify_interval: float = 3.0,
         on_unknown_sample: Optional[
-            "Callable[[int, np.ndarray, np.ndarray, Tuple[int,int,int,int], str], None]"
+            "Callable[[int, np.ndarray, np.ndarray, Tuple[int,int,int,int], str, Optional[np.ndarray], float], Optional[str]]"
         ] = None,
         on_confident_sample: Optional[
             "Callable[[int, str, np.ndarray, np.ndarray, float], None]"
@@ -254,7 +254,9 @@ class FaceTracker:
         # UUID to a different one. Signature: (track_id, old_uuid, new_uuid).
         # Set as a plain attribute (like on_unknown_sample) by run.py, wired to
         # the auto-merge handler. None = feature off.
-        self.on_identity_flip = None
+        self.on_identity_flip: Optional[
+            Callable[[int, str, str], None]
+        ] = None
 
         # Gallery (set via set_gallery). All three arrays are parallel —
         # row i of _gal_feats has name _gal_labels[i] and UUID _gal_uuids[i].
@@ -854,7 +856,7 @@ class FaceTracker:
     def _run_recognition_batch(
         self,
         frame: np.ndarray,
-        need_recog: List[Tuple[int, np.ndarray, Optional[np.ndarray]]],
+        need_recog: List[Tuple[int, np.ndarray, Optional[np.ndarray], float]],
         now: float,
     ) -> None:
         """Embed unidentified tracks in one TRT call and update their votes."""

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/face_tracker.py
@@ -138,6 +138,16 @@ class _TrackIdentity:
     # Used by the auto-enroll system to time how long a face has been
     # unknown.
     unknown_since: float = 0.0
+    # ISO timestamp of the gallery's ``last_seen_at`` at the moment this
+    # track first identified to a known UUID. Captured BEFORE any
+    # touch_last_seen call from this session, so it reflects the
+    # PREVIOUS sighting of this UUID — not "right now".
+    # Stays sticky for the lifetime of the track session: even as the
+    # gallery's last_seen_at is updated every frame, this field doesn't
+    # change. That gives the LLM consistent "we've met before" / "newcomer"
+    # signal throughout a single conversation.
+    # None until the first confident identification.
+    session_last_seen_iso: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +219,9 @@ class FaceTracker:
         on_unknown_sample: Optional[
             "Callable[[int, np.ndarray, np.ndarray, Tuple[int,int,int,int], str], None]"
         ] = None,
+        on_confident_sample: Optional[
+            "Callable[[int, str, np.ndarray, np.ndarray, float], None]"
+        ] = None,
     ):
         self.arc = arc
         self.recog_interval = float(recog_interval)
@@ -225,6 +238,11 @@ class FaceTracker:
         # Used by AutoEnroller to buffer unknown faces and drop committed
         # ones — keeping face_tracker unaware of storage concerns.
         self.on_unknown_sample = on_unknown_sample
+        # Callback fired only on confident per-frame identifications.
+        # Signature: (track_id, uuid, aligned_crop, embedding, sim).
+        # Used by SampleRefreshManager for continuous-learning sample
+        # enrichment. Guard A (sim threshold) is the caller's responsibility.
+        self.on_confident_sample = on_confident_sample
 
         # Gallery (set via set_gallery). All three arrays are parallel —
         # row i of _gal_feats has name _gal_labels[i] and UUID _gal_uuids[i].
@@ -727,6 +745,11 @@ class FaceTracker:
         for r in results:
             x1, y1, x2, y2 = r.bbox
             area = (x2 - x1) * (y2 - y1)
+            # Look up the snapshotted session-start last_seen for this
+            # track. Falls back to None for tracks not yet confidently
+            # identified (e.g. "unknown" status, or first few frames).
+            ident = self._identities.get(r.track_id)
+            session_last_seen = ident.session_last_seen_iso if ident else None
             faces.append(
                 {
                     "name": r.raw_name if r.raw_name else "unknown",
@@ -735,6 +758,7 @@ class FaceTracker:
                     "bbox": r.bbox,
                     "area": area,
                     "track_id": r.track_id,
+                    "session_last_seen_iso": session_last_seen,
                 }
             )
         return sorted(faces, key=lambda f: f["area"], reverse=True)
@@ -938,6 +962,29 @@ class FaceTracker:
                 tier,
             )
 
+            # Notify refresh manager on confident identifications. Refresh
+            # manager applies its own guards (rate-limit, diversity) before
+            # actually folding the sample into the gallery. We pass the
+            # specific UUID this frame matched (vote_uuid) — could differ
+            # from the track's finalized UUID if the track's voting hasn't
+            # converged yet, but for confident per-frame matches the
+            # difference is rarely material.
+            if (
+                tier == sl.TIER_CONFIDENT
+                and vote_uuid
+                and self.on_confident_sample is not None
+            ):
+                try:
+                    self.on_confident_sample(
+                        track_id,
+                        vote_uuid,
+                        crops[idx],
+                        feats[idx],
+                        s1,
+                    )
+                except Exception as e:
+                    log.warning("on_confident_sample callback raised: %s", e)
+
             # Decide as soon as we have enough votes or hit the cap
             if (
                 len(ident.vote_names) >= self.vote_frames
@@ -1115,10 +1162,37 @@ class FaceTracker:
                 "frames_seen": ident.frames_seen,
                 "recog_attempts": ident.recog_attempts,
                 "votes": len(ident.vote_names),
+                "session_last_seen_iso": ident.session_last_seen_iso,
             }
             for tid, ident in self._identities.items()
             if tid in self._active_ids
         }
+
+    def maybe_set_session_last_seen(self, track_id: int, iso: Optional[str]) -> bool:
+        """If this track has no ``session_last_seen_iso`` yet, set it.
+
+        Called by the on_confident_sample wiring in run.py the first time
+        a track is confidently identified, BEFORE touching the gallery's
+        last_seen_at. After that, subsequent confident matches in the same
+        track session preserve the snapshotted value (sticky).
+
+        Returns True if set this call, False if already set (or unknown
+        track).
+        """
+        ident = self._identities.get(track_id)
+        if ident is None:
+            return False
+        if ident.session_last_seen_iso is not None:
+            return False
+        ident.session_last_seen_iso = iso
+        return True
+
+    def get_session_last_seen(self, track_id: int) -> Optional[str]:
+        """Read the sticky session-start last_seen for a track, or None."""
+        ident = self._identities.get(track_id)
+        if ident is None:
+            return None
+        return ident.session_last_seen_iso
 
     def get_faces(self) -> list:
         """All faces in the current frame, sorted by bbox area descending.

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
@@ -282,12 +282,108 @@ class GalleryManager:
         cv2.imwrite(absf, img_112_bgr, [cv2.IMWRITE_JPEG_QUALITY, 95])
 
         # Embed & append
-        vec = self._embed_single(img_112_bgr)
+        vec = self.embed_aligned(img_112_bgr)
         row = self._append_vectors(vec[None, :])
         self._index["items"][rel] = {"row": row, "label": label}
         self._save_index()
         self._recompute_stats()
         return rel
+
+    def add_aligned_no_stats(
+        self,
+        label: str,
+        img_112_bgr: np.ndarray,
+        vec: Optional[np.ndarray] = None,
+        fname_hint: Optional[str] = None,
+    ) -> str:
+        """
+        Add a 112×112 aligned snapshot WITHOUT recomputing stats.
+
+        Designed for multi-shot batch enrollment (e.g. /selfie collects N frames
+        and saves them all in one go). Behaves like ``add_aligned_snapshot`` but:
+
+        - Skips the trailing ``_recompute_stats()`` call. Caller MUST invoke
+          ``recompute_stats()`` after the batch finishes; otherwise stats.json
+          stays stale until the next refresh.
+        - If ``vec`` is provided, uses it directly (must be L2-normalized).
+          Avoids re-embedding the same crop when the caller already has it
+          (e.g. /selfie pipeline embedded it for dedup/novelty/consistency).
+
+        Parameters
+        ----------
+        label : str
+            Identity name (subfolder under gallery).
+        img_112_bgr : np.ndarray
+            Aligned BGR crop of shape ``(112,112,3)`` (will be resized if needed).
+        vec : np.ndarray, optional
+            Pre-computed L2-normalized embedding of shape ``(dim,)``. If
+            supplied and valid, the crop is not re-embedded. If shape/norm
+            looks wrong, falls back to a fresh embedding.
+        fname_hint : str, optional
+            Preferred filename (``.jpg`` appended if missing), by default ``None``.
+
+        Returns
+        -------
+        str
+            Relative path of the saved aligned image
+            (e.g., ``"wendy/aligned/2026-05-19T18-30-00_00.jpg"``).
+        """
+        if img_112_bgr is None or img_112_bgr.size == 0:
+            raise ValueError("empty snapshot")
+
+        if img_112_bgr.shape[:2] != (self.aligned_size, self.aligned_size):
+            img_112_bgr = cv2.resize(
+                img_112_bgr, (self.aligned_size, self.aligned_size)
+            )
+
+        # Save to gallery/<label>/aligned/ with collision-safe filename
+        label_dir = osp.join(self.gallery_dir, label, "aligned")
+        _ensure_dir(label_dir)
+        base = (fname_hint or f"{_now_iso()}.jpg").strip()
+        if not base.lower().endswith(".jpg"):
+            base += ".jpg"
+        rel = osp.join(label, "aligned", base).replace("\\", "/")
+        absf = osp.join(self.gallery_dir, rel)
+        i = 0
+        while osp.exists(absf):
+            i += 1
+            stem, ext = osp.splitext(base)
+            rel = osp.join(label, "aligned", f"{stem}_{i}{ext}").replace("\\", "/")
+            absf = osp.join(self.gallery_dir, rel)
+
+        cv2.imwrite(absf, img_112_bgr, [cv2.IMWRITE_JPEG_QUALITY, 95])
+
+        # Embed (or use the provided vector with defensive validation)
+        if vec is None:
+            vec = self.embed_aligned(img_112_bgr)
+        else:
+            vec = np.asarray(vec, dtype=np.float32).reshape(-1)
+            if vec.shape[0] != self._dim:
+                vec = self.embed_aligned(img_112_bgr)
+            else:
+                n = float(np.linalg.norm(vec))
+                if n < 1e-9:
+                    vec = self.embed_aligned(img_112_bgr)
+                elif abs(n - 1.0) > 1e-4:
+                    vec = (vec / n).astype(np.float32, copy=False)
+
+        # Append to vectors.f32 + update index
+        row = self._append_vectors(vec[None, :])
+        self._index["items"][rel] = {"row": int(row), "label": label}
+        self._save_index()
+        # NB: deliberately NO self._recompute_stats() here — caller does it once
+        return rel
+
+    def recompute_stats(self) -> None:
+        """
+        Public wrapper for ``_recompute_stats()``.
+
+        Call once at the end of a batch of ``add_aligned_no_stats()`` to update
+        per-identity centroids in stats.json. Behaviorally identical to the
+        internal ``_recompute_stats``; the wrapper exists so external callers
+        don't have to reach into an underscored name.
+        """
+        self._recompute_stats()
 
     def delete_identity(self, label: str) -> tuple[bool, int, int, int]:
         """
@@ -568,8 +664,13 @@ class GalleryManager:
         )
         return len(rels), feats.shape[0]
 
-    def _embed_single(self, img_112_bgr: np.ndarray) -> np.ndarray:
+    def embed_aligned(self, img_112_bgr: np.ndarray) -> np.ndarray:
         """Embed a single aligned 112×112 BGR crop and L2-normalize the vector.
+
+        Public method used by:
+        - Internal save paths (``add_aligned_snapshot``, ``add_aligned_no_stats``)
+        - External callers (e.g. ``HttpAPI._handle_selfie``) for dedup,
+          consistency, and novelty checks — no disk I/O.
 
         Parameters
         ----------
@@ -579,7 +680,7 @@ class GalleryManager:
         Returns
         -------
         np.ndarray
-            Normalized embedding vector of shape ``(dim,)`` with dtype float32.
+            L2-normalized embedding of shape ``(dim,)`` with dtype float32.
         """
         vec = self.arc.infer([img_112_bgr])
         if vec.ndim == 2 and vec.shape[0] == 1:

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
@@ -1,23 +1,48 @@
 """
-Gallery & embedding manager for face recognition.
+UUID-keyed face gallery with per-identity self-contained folders.
 
-This module manages a disk-backed face gallery and its embedding store.
-It aligns new photos (optionally from `raw/` using SCRFD) into 112×112
-`aligned/` crops, embeds them with AdaFace (TensorRT), and persists the
-results under `embeds/<model_sig>/{index.json,vectors.f32,stats.json}`.
-It supports incremental refresh (only process new files), adding single
-aligned snapshots, clearing & rebuilding, and computing per-identity mean
-vectors for fast runtime recognition.
+Layout
+------
+gallery/
+  <uuid>/
+    metadata.json     # {uuid, name, created_at, updated_at, sample_count,
+                      #  source, notes?}
+    aligned/          # 112x112 BGR JPGs
+      sample_001.jpg
+      sample_002.jpg
+      ...
+    embeddings.npy    # (k, 512) float32, L2-normalized, one row per sample
+    centroid.npy      # (512,) float32, L2-normalized incremental mean
+  _legacy/            # one-shot migration moves old <name>/ folders here
+  _trash/             # forget()'d UUIDs (soft delete, restorable)
 
-Typical usage:
-- At startup (or after HTTP actions like /gallery/refresh, /gallery/add_aligned,
-  /gallery/add_raw, /selfie), refresh the gallery and fetch identity means.
-- At inference time, compare a face embedding to the returned per-identity means.
+Why UUIDs not names
+-------------------
+- Renames are O(1): just update metadata.name (no folder rename, no GPU work,
+  no embedding store rewrite).
+- Multiple "profiles" per name are natural: two distinct UUIDs can both be
+  named "wendy" (e.g. one auto-enrolled, one selfie). Either can be deleted
+  independently.
+- Auto-enrolled identities start with name="" (anonymous) and get named
+  later when the LLM asks. The UUID never changes — only the metadata.
+- Privacy: filenames don't leak identities; the UUID is opaque on disk.
+  metadata.json is the only place names live, and can be encrypted later.
 
-Notes
------
-- Embeddings are float32; vectors are L2-normalized before similarity.
-- Batch size respects the AdaFace TensorRT optimization profile (`arc_max_bs`).
+Why per-folder embeddings (vs one global file)
+----------------------------------------------
+- forget(uuid) is rmtree on one folder — O(1) filesystem op, no GPU.
+  The old design rebuilt the entire embedding store on every delete, which
+  was ~25 seconds at 1000 identities × 5 samples.
+- add_sample updates one centroid incrementally — O(1), no scan of others.
+- get_centroids() scans folders at load and caches; in-memory after that.
+
+Threading model
+---------------
+All gallery write operations should be called from a single thread (the
+main loop, via run_job_sync). This module does NOT take internal locks —
+the caller is responsible for serialization. Reads (get_centroids,
+list_identities) are safe to call from any thread but should ideally also
+be serialized with writes.
 """
 
 from __future__ import annotations
@@ -26,19 +51,33 @@ import json
 import logging
 import os
 import os.path as osp
+import re
 import shutil
 import time
+import uuid as uuidlib
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 import cv2
 import numpy as np
 
-from .adaface import TRTFaceRecognition, warp_face_by_5p
-from .scrfd import TRTSCRFD
-from .utils import infer_arc_batched, list_images  # helpers
+from .adaface import TRTFaceRecognition
 
 log = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+
+# UUIDs are written as plain hex strings (no dashes) to keep filenames short.
+# Regex matches both lowercase hex strings and standard 8-4-4-4-12 format.
+_UUID_RE = re.compile(
+    r"^[a-f0-9]{32}$|^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+)
+
+# Reserved directory names — never treated as UUIDs.
+_RESERVED_DIRS = frozenset({"_legacy", "_trash", "embeds"})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _ensure_dir(d: str) -> None:
@@ -46,755 +85,864 @@ def _ensure_dir(d: str) -> None:
 
 
 def _now_iso() -> str:
-    return time.strftime("%Y-%m-%dT%H-%M-%S")
+    return time.strftime("%Y-%m-%dT%H:%M:%S")
 
 
-def make_model_sig(arc: TRTFaceRecognition, extra: Optional[str] = None) -> str:
-    """Build a readable, deterministic model signature for the embedding store.
+def _is_uuid_dir(name: str) -> bool:
+    return bool(_UUID_RE.match(name))
+
+
+def _atomic_write_json(path: str, obj: dict) -> None:
+    """Write JSON via temp-file + rename so partial writes can't corrupt.
+
+    Crashes between the write and rename leave the previous file intact.
+    """
+    _ensure_dir(osp.dirname(path))
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(obj, f, ensure_ascii=False, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+def _atomic_write_npy(path: str, arr: np.ndarray) -> None:
+    """Write .npy via temp + rename. Same crash-safety as JSON above."""
+    _ensure_dir(osp.dirname(path))
+    tmp = f"{path}.tmp.{os.getpid()}"
+    np.save(tmp, arr.astype(np.float32, copy=False))
+    # np.save appends .npy automatically if extension missing — handle that.
+    if not osp.exists(tmp) and osp.exists(tmp + ".npy"):
+        tmp = tmp + ".npy"
+    os.replace(tmp, path)
+
+
+def _l2_normalize(v: np.ndarray) -> np.ndarray:
+    """L2-normalize, defensive against zero vectors."""
+    n = float(np.linalg.norm(v))
+    if n < 1e-12:
+        return v.astype(np.float32, copy=False)
+    return (v / n).astype(np.float32, copy=False)
+
+
+def _new_uuid(existing: set) -> str:
+    """Generate a fresh UUID4 (hex form, 32 chars).
+
+    UUID4 collision is astronomically unlikely (~10^-15 at 100M UUIDs), but
+    we retry on the off chance to be safe — also catches the case where a
+    user manually copied a folder.
+    """
+    for _ in range(10):
+        u = uuidlib.uuid4().hex
+        if u not in existing:
+            return u
+    raise RuntimeError("UUID generation collision (10x). Bug or corrupt state.")
+
+
+# ---------------------------------------------------------------------------
+# Per-UUID record (in-memory representation)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IdentityRecord:
+    """In-memory snapshot of one UUID folder.
+
+    Fields are populated from metadata.json + centroid.npy + the aligned/ dir.
+    Mutations on this object are NOT written back automatically — call
+    ``UUIDGallery.save_metadata(record)`` after mutating ``record.metadata``.
+
+    Centroid representation
+    -----------------------
+    ``centroid_sum`` is the UN-normalized sum of all sample embeddings — i.e.
+    ``sum(embeddings)``, not ``mean(embeddings)`` and not L2-normalized. This
+    is what we persist in ``centroid.npy``.
+
+    Why store the sum (not the L2-normalized mean):
+    Adding a new sample is just ``sum_new = sum_old + emb``. If we stored the
+    L2-normalized mean, we'd lose the magnitude information needed to weight
+    the existing mean correctly when folding in a new vector. Storing the
+    sum keeps the add operation O(1) and mathematically equivalent to a
+    full recompute.
+
+    The L2-normalized form (what face recognition actually uses) is computed
+    on the fly in :meth:`UUIDGallery.get_centroids` — that's just N vector
+    normalizations, trivial even at thousands of identities.
+    """
+
+    uuid: str
+    name: str
+    sample_count: int
+    centroid_sum: Optional[np.ndarray] = None  # un-normalized sum, (512,)
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def is_named(self) -> bool:
+        """True if this identity has a non-empty display name (i.e. not anon)."""
+        return bool(self.name and self.name.strip())
+
+    @property
+    def centroid_normalized(self) -> Optional[np.ndarray]:
+        """Lazy L2-normalized centroid for similarity comparisons."""
+        if self.centroid_sum is None:
+            return None
+        return _l2_normalize(self.centroid_sum)
+
+
+# ---------------------------------------------------------------------------
+# UUIDGallery
+# ---------------------------------------------------------------------------
+
+
+class UUIDGallery:
+    """Disk-backed face gallery keyed by UUID.
 
     Parameters
     ----------
-    arc : TRTFaceRecognition
-        AdaFace TensorRT wrapper; used to read model name and embedding dimension.
-    extra : str, optional
-        Extra token to append (e.g., engine variant), by default ``None``.
-
-    Returns
-    -------
-    str
-        Signature string like ``"{name}-trt-l2-{dim}[-{extra}]"``.
-    """
-    name = getattr(arc, "name", None) or getattr(arc, "model_name", None) or "arc"
-    dim = int(getattr(arc, "embedding_dim", 512))
-    backend = "trt"
-    norm = "l2"
-    parts = [str(name), backend, norm, str(dim)]
-    if extra:
-        parts.append(str(extra))
-    return "-".join(parts)
-
-
-def _align_largest_face_bgr(
-    img_bgr: np.ndarray,
-    det: TRTSCRFD,
-    conf: float,
-    size: int = 112,
-) -> Optional[np.ndarray]:
-    """
-    Detect faces, choose the largest, align with 5p if available, else crop+resize.
-    Returns a size×size BGR crop or None if no face.
-    """
-    dets, kpss = det.detect(img_bgr, conf=conf)
-    if dets is None or dets.shape[0] == 0:
-        return None
-    areas = (dets[:, 2] - dets[:, 0]) * (dets[:, 3] - dets[:, 1])
-    idx = int(np.argmax(areas))
-    if kpss is not None:
-        try:
-            return warp_face_by_5p(img_bgr, kpss[idx], size)
-        except Exception:
-            pass
-    x1, y1, x2, y2, _ = dets[idx].astype(int)
-    face = img_bgr[max(0, y1) : max(0, y2), max(0, x1) : max(0, x2)]
-    if face.size == 0:
-        return None
-    return cv2.resize(face, (size, size))
-
-
-class GalleryManager:
-    """
-    Gallery manager for face recognition.
-
-    Manages a face gallery with aligned crops and an embedding store. It supports incremental refresh from
-    ``raw/`` and ``aligned/``, batched embedding respecting the AdaFace TensorRT max batch size, and per-identity statistics (counts and mean vectors)
-
-    Layout:
-      gallery/
-        Alice/ aligned/*.jpg   (112x112)  [source of truth]
-               raw/*.jpg       (optional; will be aligned -> aligned/]
-        Bob/   aligned/*.jpg
-      embeds/
-        <model_sig>/
-          index.json    { "meta": {...}, "items": { "Alice/aligned/foo.jpg": {"row":0,"label":"Alice"}, ... } }
-          vectors.f32   float32 raw, concatenated (N * dim)
-          stats.json    { "labels": {"Alice": {"count": X, "mean": [...]}}, "count": N, "dim": dim }
-
-    Typical usage:
-      gm = GalleryManager(gallery_dir, embeds_dir, arc, scrfd)
-      gm.refresh()                    # incremental: align new raw/, embed new aligned/
-      feats, labels = gm.get_identity_means()  # per-identity means (for recognition)
-
-    Attributes
-    ----------
     gallery_dir : str
-        Absolute path to the gallery root (one subfolder per identity).
-    embeds_root : str
-        Absolute path to the embeddings root folder.
+        Root directory containing the UUID folders.
     arc : TRTFaceRecognition
-        AdaFace TensorRT wrapper used for feature extraction.
-    scrfd : TRTSCRFD or None
-        SCRFD detector used to align new images from ``raw/``.
-    det_conf : float
-        Detection confidence threshold for alignment.
-    aligned_size : int
-        Aligned face crop size (pixels).
-    model_sig : str
-        Model signature used to segregate embed stores.
-    arc_max_bs : int
-        Maximum AdaFace batch size (matches TRT optimization profile).
-    store_dir : str
-        Directory under ``embeds_root`` for this model signature.
-    index_path : str
-        JSON index mapping relative image paths to row indices and labels.
-    vectors_path : str
-        Binary file storing concatenated float32 embeddings ``(N * dim)``.
-    stats_path : str
-        JSON file with per-identity counts and mean vectors.
+        AdaFace TRT engine for embedding extraction. Used by ``embed_aligned``
+        and any operation that adds a sample without a pre-computed vector.
+    aligned_size : int, default 112
+        Face crop dimension. Almost always 112 for AdaFace/ArcFace.
     """
 
     def __init__(
         self,
         gallery_dir: str,
-        embeds_dir: str,
         *,
         arc: TRTFaceRecognition,
-        scrfd: Optional[TRTSCRFD] = None,
-        det_conf: float = 0.5,
         aligned_size: int = 112,
-        model_sig: Optional[str] = None,
-        arc_max_bs: int = 4,  # IMPORTANT: respect TensorRT optimization profile (e.g., 1..4)
     ) -> None:
-        """
-        Initialize the gallery manager and load/create the embed store.
-        """
         self.gallery_dir = osp.abspath(gallery_dir)
-        self.embeds_root = osp.abspath(embeds_dir)
         self.arc = arc
-        self.scrfd = scrfd
-        self.det_conf = float(det_conf)
         self.aligned_size = int(aligned_size)
-        self.model_sig = model_sig or make_model_sig(arc)
-        self.arc_max_bs = int(arc_max_bs)
+        self._dim = int(getattr(arc, "embedding_dim", 512))
 
-        # Paths under embeds/
-        self.store_dir = osp.join(self.embeds_root, self.model_sig)
-        self.index_path = osp.join(self.store_dir, "index.json")
-        self.vectors_path = osp.join(self.store_dir, "vectors.f32")
-        self.stats_path = osp.join(self.store_dir, "stats.json")
+        _ensure_dir(self.gallery_dir)
+        _ensure_dir(osp.join(self.gallery_dir, "_trash"))
 
-        _ensure_dir(self.store_dir)
-        self._index = self._load_index()
-        self._dim = int(getattr(self.arc, "embedding_dim", 512))
+        # In-memory cache: uuid → IdentityRecord. Populated on demand by
+        # _load() and refreshed by reload().
+        self._records: Dict[str, IdentityRecord] = {}
+        self.reload()
 
-    def refresh(self, process_raw: bool = True) -> Tuple[int, int]:
+    # ==================================================================
+    # Loading
+    # ==================================================================
+
+    def reload(self) -> int:
+        """Scan ``gallery_dir`` and rebuild the in-memory record cache.
+
+        Returns the number of UUIDs loaded. Call this after external
+        modifications to ``gallery_dir`` (e.g. file-level rsync).
         """
-        Incrementally update the embed store.
-
-        - Optionally process new images in `raw/`: detect→align→write into `aligned/`.
-        - Embed any new 112×112 crops under `aligned/` and append to vectors.
-
-        Parameters
-        ----------
-        process_raw : bool, optional
-            Whether to detect→align images from ``raw/`` into ``aligned/``, by default ``True``.
-
-        Returns
-        -------
-          (num_aligned_added, num_vectors_appended)
-        """
-        if process_raw and self.scrfd is None:
-            log.warning(
-                "refresh(): 'process_raw=True' but SCRFD was not provided; skipping raw/"
-            )
-
-        if process_raw and self.scrfd is not None:
-            self._harvest_raw_to_aligned()
-
-        added = self._embed_new_aligned()
-        self._recompute_stats()
-        return added
-
-    def clear_and_rebuild(self) -> Tuple[int, int]:
-        """Delete current vectors and rebuild embeddings from ``aligned/`` only.
-
-        Returns
-        -------
-        tuple[int, int]
-            ``(num_aligned_added, num_vectors_appended)`` after rebuild.
-        """
-        if osp.exists(self.vectors_path):
+        self._records.clear()
+        if not osp.isdir(self.gallery_dir):
+            return 0
+        for entry in os.listdir(self.gallery_dir):
+            if entry in _RESERVED_DIRS:
+                continue
+            path = osp.join(self.gallery_dir, entry)
+            if not osp.isdir(path):
+                continue
+            if not _is_uuid_dir(entry):
+                # Legacy folder; needs migration via migrate_legacy().
+                log.warning(
+                    "Skipping non-UUID directory '%s' (run migrate_legacy)",
+                    entry,
+                )
+                continue
             try:
-                os.remove(self.vectors_path)
-            except Exception:
-                pass
-        self._index = {"meta": self._index.get("meta", {}), "items": {}}
-        self._save_index()
+                rec = self._load(entry)
+                if rec is not None:
+                    self._records[entry] = rec
+            except Exception as e:
+                log.warning("Failed to load UUID %s: %s", entry, e)
+        log.info("Gallery loaded: %d UUIDs", len(self._records))
+        return len(self._records)
 
-        added = self._embed_new_aligned()
-        self._recompute_stats()
-        return added
+    def _load(self, uuid: str) -> Optional[IdentityRecord]:
+        """Load one UUID's record from disk. Returns None on corrupted entry."""
+        uuid_dir = osp.join(self.gallery_dir, uuid)
+        meta_path = osp.join(uuid_dir, "metadata.json")
+        centroid_path = osp.join(uuid_dir, "centroid.npy")
 
-    def add_aligned_snapshot(
-        self, label: str, img_112_bgr: np.ndarray, fname_hint: Optional[str] = None
-    ) -> str:
-        """
-        Add a new 112×112 face (already aligned) under gallery/<label>/aligned,
-        then embed and append to the store. Returns the relative aligned path.
+        if not osp.exists(meta_path):
+            log.warning("UUID %s missing metadata.json", uuid)
+            return None
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                meta = json.load(f)
+        except Exception as e:
+            log.warning("UUID %s metadata.json invalid: %s", uuid, e)
+            return None
 
-        Parameters
-        ----------
-        label : str
-            Identity name (subfolder under gallery).
-        img_112_bgr : np.ndarray
-            Aligned BGR crop of shape ``(112,112,3)`` (will be resized if needed).
-        fname_hint : str, optional
-            Preferred filename (``.jpg`` added if missing), by default ``None``.
+        centroid_sum: Optional[np.ndarray] = None
+        if osp.exists(centroid_path):
+            try:
+                centroid_sum = np.load(centroid_path).astype(np.float32)
+                if centroid_sum.shape != (self._dim,):
+                    log.warning(
+                        "UUID %s centroid shape %s, expected (%d,)",
+                        uuid,
+                        centroid_sum.shape,
+                        self._dim,
+                    )
+                    centroid_sum = None
+            except Exception as e:
+                log.warning("UUID %s centroid.npy invalid: %s", uuid, e)
+
+        sample_count = int(meta.get("sample_count", 0))
+        # Cross-check sample_count against actual files (cheap sanity check)
+        aligned_dir = osp.join(uuid_dir, "aligned")
+        if osp.isdir(aligned_dir):
+            actual = len([f for f in os.listdir(aligned_dir) if f.endswith(".jpg")])
+            if actual != sample_count:
+                log.debug(
+                    "UUID %s: metadata sample_count=%d, actual files=%d (will fix)",
+                    uuid,
+                    sample_count,
+                    actual,
+                )
+                sample_count = actual
+                meta["sample_count"] = actual
+
+        return IdentityRecord(
+            uuid=uuid,
+            name=str(meta.get("name", "")),
+            sample_count=sample_count,
+            centroid_sum=centroid_sum,
+            metadata=meta,
+        )
+
+    # ==================================================================
+    # Read APIs (called from recognition + UI)
+    # ==================================================================
+
+    def get_centroids(self) -> Tuple[np.ndarray, List[str], List[str]]:
+        """Build the (feats, names, uuids) triple consumed by face_tracker.
+
+        Only includes UUIDs with at least one sample. Names are the
+        human-readable labels from metadata.json — they may be empty for
+        auto-enrolled (yet-to-be-named) identities.
 
         Returns
         -------
-        str
-            Relative path of the saved aligned image (e.g., ``"Alice/aligned/xxx.jpg"``).
+        feats : (N, 512) float32
+            L2-normalized centroids, one row per included UUID.
+        names : list[str]
+            Display names, parallel to ``feats``.
+        uuids : list[str]
+            UUIDs, parallel to ``feats``. Use this for stable identity refs
+            (e.g. /set_name, /forget).
         """
-        if img_112_bgr is None or img_112_bgr.size == 0:
-            raise ValueError("empty snapshot")
+        feats_list: List[np.ndarray] = []
+        names: List[str] = []
+        uuids: List[str] = []
+        for u, rec in self._records.items():
+            if rec.centroid_sum is None or rec.sample_count == 0:
+                continue
+            # Normalize the running sum for cosine-similarity use. Storing
+            # the un-normalized sum on disk lets add_sample stay O(1); the
+            # per-frame normalization here is N vector norms (trivial).
+            feats_list.append(_l2_normalize(rec.centroid_sum))
+            names.append(rec.name)
+            uuids.append(u)
+        if not feats_list:
+            return np.zeros((0, self._dim), dtype=np.float32), [], []
+        return np.stack(feats_list, axis=0).astype(np.float32), names, uuids
 
-        if img_112_bgr.shape[:2] != (self.aligned_size, self.aligned_size):
-            img_112_bgr = cv2.resize(
-                img_112_bgr, (self.aligned_size, self.aligned_size)
+    def get_record(self, uuid: str) -> Optional[IdentityRecord]:
+        """Look up a single UUID's record."""
+        return self._records.get(uuid)
+
+    def get_metadata(self, uuid: str) -> Optional[dict]:
+        """Return metadata.json contents for ``uuid``, or None if unknown."""
+        rec = self._records.get(uuid)
+        return dict(rec.metadata) if rec is not None else None
+
+    def list_identities(self, include_unnamed: bool = True) -> List[dict]:
+        """Public listing of all identities (one dict per UUID).
+
+        Used by /gallery/identities. Returns lightweight summary dicts —
+        not full centroids.
+        """
+        out: List[dict] = []
+        for u, rec in sorted(self._records.items()):
+            if not include_unnamed and not rec.is_named:
+                continue
+            out.append(
+                {
+                    "uuid": u,
+                    "name": rec.name,
+                    "sample_count": rec.sample_count,
+                    "created_at": rec.metadata.get("created_at"),
+                    "updated_at": rec.metadata.get("updated_at"),
+                    "source": rec.metadata.get("source"),
+                }
             )
+        return out
 
-        # Save
-        label_dir = osp.join(self.gallery_dir, label, "aligned")
-        _ensure_dir(label_dir)
-        base = (fname_hint or f"{_now_iso()}.jpg").strip()
-        if not base.lower().endswith(".jpg"):
-            base += ".jpg"
-        rel = osp.join(label, "aligned", base).replace("\\", "/")
-        absf = osp.join(self.gallery_dir, rel)
-        # unique filename if exists
-        i = 0
-        while osp.exists(absf):
-            i += 1
-            stem, ext = osp.splitext(base)
-            rel = osp.join(label, "aligned", f"{stem}_{i}{ext}").replace("\\", "/")
-            absf = osp.join(self.gallery_dir, rel)
+    def find_by_name(self, name: str) -> List[str]:
+        """All UUIDs whose name matches ``name`` (case-insensitive).
 
-        cv2.imwrite(absf, img_112_bgr, [cv2.IMWRITE_JPEG_QUALITY, 95])
+        Multiple UUIDs may share the same name (e.g. enrolled twice). The
+        caller decides what to do — typically, the first or the one with
+        the most samples.
+        """
+        target = name.strip().lower()
+        return [
+            u for u, rec in self._records.items() if rec.name.strip().lower() == target
+        ]
 
-        # Embed & append
-        vec = self.embed_aligned(img_112_bgr)
-        row = self._append_vectors(vec[None, :])
-        self._index["items"][rel] = {"row": row, "label": label}
-        self._save_index()
-        self._recompute_stats()
-        return rel
+    def num_identities(self) -> int:
+        """Number of UUIDs with at least one sample."""
+        return sum(1 for r in self._records.values() if r.sample_count > 0)
 
-    def add_aligned_no_stats(
+    # ==================================================================
+    # Write APIs — create / append / rename / delete
+    # ==================================================================
+
+    def create(self, name: str = "", source: str = "selfie", **extra) -> str:
+        """Create an empty UUID folder. Returns the new UUID.
+
+        The folder is created on disk immediately; ``add_sample`` is required
+        before the UUID will show up in ``get_centroids``.
+
+        Parameters
+        ----------
+        name : str
+            Display name. Use ``""`` for auto-enrolled / anonymous identities;
+            ``set_name`` later when the name is known.
+        source : str
+            Provenance tag (``"selfie"``, ``"auto_enroll"``, ``"migration"``,
+            ``"add_raw"``, ...). Helps with debugging and audit.
+        extra : dict
+            Extra metadata key/values to merge into metadata.json (e.g.
+            ``notes="enrolled at GTC"``).
+        """
+        u = _new_uuid(set(self._records.keys()))
+        uuid_dir = osp.join(self.gallery_dir, u)
+        _ensure_dir(uuid_dir)
+        _ensure_dir(osp.join(uuid_dir, "aligned"))
+
+        meta = {
+            "uuid": u,
+            "name": name,
+            "created_at": _now_iso(),
+            "updated_at": _now_iso(),
+            "sample_count": 0,
+            "source": source,
+            **extra,
+        }
+        _atomic_write_json(osp.join(uuid_dir, "metadata.json"), meta)
+
+        self._records[u] = IdentityRecord(
+            uuid=u,
+            name=name,
+            sample_count=0,
+            centroid_sum=None,
+            metadata=meta,
+        )
+        log.info("Created UUID %s (name=%r, source=%s)", u, name, source)
+        return u
+
+    def add_sample(
         self,
-        label: str,
-        img_112_bgr: np.ndarray,
-        vec: Optional[np.ndarray] = None,
+        uuid: str,
+        aligned_112_bgr: np.ndarray,
+        embedding: Optional[np.ndarray] = None,
+        *,
         fname_hint: Optional[str] = None,
     ) -> str:
-        """
-        Add a 112×112 aligned snapshot WITHOUT recomputing stats.
-
-        Designed for multi-shot batch enrollment (e.g. /selfie collects N frames
-        and saves them all in one go). Behaves like ``add_aligned_snapshot`` but:
-
-        - Skips the trailing ``_recompute_stats()`` call. Caller MUST invoke
-          ``recompute_stats()`` after the batch finishes; otherwise stats.json
-          stays stale until the next refresh.
-        - If ``vec`` is provided, uses it directly (must be L2-normalized).
-          Avoids re-embedding the same crop when the caller already has it
-          (e.g. /selfie pipeline embedded it for dedup/novelty/consistency).
-
-        Parameters
-        ----------
-        label : str
-            Identity name (subfolder under gallery).
-        img_112_bgr : np.ndarray
-            Aligned BGR crop of shape ``(112,112,3)`` (will be resized if needed).
-        vec : np.ndarray, optional
-            Pre-computed L2-normalized embedding of shape ``(dim,)``. If
-            supplied and valid, the crop is not re-embedded. If shape/norm
-            looks wrong, falls back to a fresh embedding.
-        fname_hint : str, optional
-            Preferred filename (``.jpg`` appended if missing), by default ``None``.
-
-        Returns
-        -------
-        str
-            Relative path of the saved aligned image
-            (e.g., ``"wendy/aligned/2026-05-19T18-30-00_00.jpg"``).
-        """
-        if img_112_bgr is None or img_112_bgr.size == 0:
-            raise ValueError("empty snapshot")
-
-        if img_112_bgr.shape[:2] != (self.aligned_size, self.aligned_size):
-            img_112_bgr = cv2.resize(
-                img_112_bgr, (self.aligned_size, self.aligned_size)
-            )
-
-        # Save to gallery/<label>/aligned/ with collision-safe filename
-        label_dir = osp.join(self.gallery_dir, label, "aligned")
-        _ensure_dir(label_dir)
-        base = (fname_hint or f"{_now_iso()}.jpg").strip()
-        if not base.lower().endswith(".jpg"):
-            base += ".jpg"
-        rel = osp.join(label, "aligned", base).replace("\\", "/")
-        absf = osp.join(self.gallery_dir, rel)
-        i = 0
-        while osp.exists(absf):
-            i += 1
-            stem, ext = osp.splitext(base)
-            rel = osp.join(label, "aligned", f"{stem}_{i}{ext}").replace("\\", "/")
-            absf = osp.join(self.gallery_dir, rel)
-
-        cv2.imwrite(absf, img_112_bgr, [cv2.IMWRITE_JPEG_QUALITY, 95])
-
-        # Embed (or use the provided vector with defensive validation)
-        if vec is None:
-            vec = self.embed_aligned(img_112_bgr)
-        else:
-            vec = np.asarray(vec, dtype=np.float32).reshape(-1)
-            if vec.shape[0] != self._dim:
-                vec = self.embed_aligned(img_112_bgr)
-            else:
-                n = float(np.linalg.norm(vec))
-                if n < 1e-9:
-                    vec = self.embed_aligned(img_112_bgr)
-                elif abs(n - 1.0) > 1e-4:
-                    vec = (vec / n).astype(np.float32, copy=False)
-
-        # Append to vectors.f32 + update index
-        row = self._append_vectors(vec[None, :])
-        self._index["items"][rel] = {"row": int(row), "label": label}
-        self._save_index()
-        # NB: deliberately NO self._recompute_stats() here — caller does it once
-        return rel
-
-    def recompute_stats(self) -> None:
-        """
-        Public wrapper for ``_recompute_stats()``.
-
-        Call once at the end of a batch of ``add_aligned_no_stats()`` to update
-        per-identity centroids in stats.json. Behaviorally identical to the
-        internal ``_recompute_stats``; the wrapper exists so external callers
-        don't have to reach into an underscored name.
-        """
-        self._recompute_stats()
-
-    def delete_identity(self, label: str) -> tuple[bool, int, int, int]:
-        """
-        Delete one identity from the gallery and rebuild the embedding store.
+        """Append one sample to an existing UUID.
 
         Steps
         -----
-        - Remove the folder `gallery/<label>/` (both raw/ and aligned/).
-        - Clear & rebuild the embed store from remaining `aligned/` photos.
-        - Recompute stats, so runtime recognition stops matching this label.
+        1. Compute embedding if not provided (GPU work).
+        2. Write JPG to ``aligned/``.
+        3. Append the embedding to ``embeddings.npy`` (full rewrite, since
+           numpy lacks streaming append for ``.npy`` format — but it's still
+           cheap, embeddings are ~2KB per row).
+        4. Update centroid incrementally: ``new = norm((old*N + emb))``.
+        5. Update metadata.sample_count and updated_at.
 
-        Parameters
-        ----------
-        label: person name: wendy
-
-        Returns
-        -------
-        (removed_gallery, aligned_used, vectors_rebuilt, identities_left)
+        Returns the filename of the saved sample (e.g. ``"sample_004.jpg"``).
         """
-        p = osp.join(self.gallery_dir, label)
-        removed_gallery = False
-        if osp.isdir(p):
-            shutil.rmtree(p)
-            removed_gallery = True
+        rec = self._records.get(uuid)
+        if rec is None:
+            raise KeyError(f"UUID not found: {uuid}")
 
-        aligned_used, vectors_rebuilt = self.clear_and_rebuild()
+        # Normalize/validate the crop
+        if aligned_112_bgr is None or aligned_112_bgr.size == 0:
+            raise ValueError("empty aligned crop")
+        crop = aligned_112_bgr
+        if crop.shape[:2] != (self.aligned_size, self.aligned_size):
+            crop = cv2.resize(crop, (self.aligned_size, self.aligned_size))
 
-        feats, labels = self.get_identity_means()
-        return removed_gallery, aligned_used, vectors_rebuilt, len(labels)
-
-    def get_all_vectors_and_labels(self) -> Tuple[np.ndarray, List[str]]:
-        """
-        Load the whole vectors file into RAM and return (vectors, labels_per_row).
-
-        Returns
-        -------
-        tuple[np.ndarray, list[str]]
-            ``(vectors, labels_per_row)`` where ``vectors`` is ``(N, dim)`` float32.
-        """
-        if not osp.exists(self.vectors_path):
-            return np.zeros((0, self._dim), np.float32), []
-        arr = np.fromfile(self.vectors_path, dtype=np.float32)
-        if arr.size % self._dim != 0:
-            raise RuntimeError("vectors.f32 is corrupted or wrong dim")
-        arr = arr.reshape((-1, self._dim))
-        labels = self._row_labels(len(arr))
-        return arr, labels
-
-    def get_identity_means(self) -> Tuple[np.ndarray, List[str]]:
-        """
-        Return per-identity mean vectors (N_id × dim) and label list.
-        Mirrors your old build_gallery_embeddings() contract.
-
-        Returns
-        -------
-        tuple[np.ndarray, list[str]]
-            ``(means, labels)`` where ``means`` is ``(N_id, dim)`` float32 and
-            each row is L2-normalized.
-        """
-        stats = self._load_stats()
-        labels: List[str] = []
-        means: List[np.ndarray] = []
-        if stats and "labels" in stats:
-            for lab, rec in stats["labels"].items():
-                if rec.get("count", 0) > 0 and "mean" in rec:
-                    labels.append(lab)
-                    means.append(np.asarray(rec["mean"], dtype=np.float32))
-        if not means:
-            return np.zeros((0, self._dim), np.float32), []
-        return np.stack(means, axis=0).astype(np.float32), labels
-
-    def legacy_build_gallery_embeddings(
-        self, det_conf: Optional[float] = None
-    ) -> Tuple[np.ndarray, List[str]]:
-        """
-        Backward-compatible shim for older call sites:
-            feats, labels = build_gallery_embeddings(gallery, scrfd, arc, det_conf)
-        Under the hood, we refresh and return per-identity means.
-
-        Parameters
-        ----------
-        det_conf : float, optional
-            Detection confidence to use during refresh, by default ``None`` (keep current).
-
-        Returns
-        -------
-        tuple[np.ndarray, list[str]]
-            ``(means, labels)`` as in :meth:`get_identity_means`.
-        """
-        if det_conf is not None:
-            self.det_conf = float(det_conf)
-        self.refresh(process_raw=True)
-        return self.get_identity_means()
-
-    def _load_index(self) -> Dict:
-        """Load or initialize the JSON index file.
-
-        Returns
-        -------
-        dict
-            Index structure with ``meta`` and ``items`` keys. ``items`` maps
-            relative image paths to ``{"row": int, "label": str}``.
-        """
-        if osp.exists(self.index_path):
-            try:
-                with open(self.index_path, "r", encoding="utf-8") as f:
-                    idx = json.load(f)
-                if "items" not in idx:
-                    idx = {"meta": {}, "items": {}}
-            except Exception:
-                idx = {"meta": {}, "items": {}}
+        # Compute or validate embedding
+        if embedding is None:
+            embedding = self.embed_aligned(crop)
         else:
-            idx = {"meta": {}, "items": {}}
-
-        idx["meta"].update(
-            {
-                "model_sig": self.model_sig,
-                "dim": int(getattr(self.arc, "embedding_dim", 512)),
-                "created": idx["meta"].get("created") or _now_iso(),
-                "updated": _now_iso(),
-            }
-        )
-        self._save_json(self.index_path, idx)
-        return idx
-
-    def _save_index(self) -> None:
-        """Update the index ``updated`` timestamp and persist to disk."""
-        self._index["meta"]["updated"] = _now_iso()
-        self._save_json(self.index_path, self._index)
-
-    def _save_json(self, path: str, obj: Dict) -> None:
-        """Write a JSON object to a file (ensuring parent directory exists)."""
-        _ensure_dir(osp.dirname(path))
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(obj, f, ensure_ascii=False, indent=2)
-
-    def _load_stats(self) -> Optional[Dict]:
-        """Load per-identity statistics from ``stats.json`` if present."""
-        if not osp.exists(self.stats_path):
-            return None
-        try:
-            with open(self.stats_path, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except Exception:
-            return None
-
-    def _recompute_stats(self) -> None:
-        """
-        Build per-identity means and counts; write to stats.json.
-        """
-        if not osp.exists(self.vectors_path):
-            stats = {
-                "count": 0,
-                "dim": self._dim,
-                "labels": {},
-                "updated": _now_iso(),
-            }
-            self._save_json(self.stats_path, stats)
-            return
-
-        vecs, row_labels = self.get_all_vectors_and_labels()
-        per: Dict[str, Dict[str, object]] = {}
-        uniq = sorted(set(row_labels))
-        for lab in uniq:
-            idxs = [i for i, L in enumerate(row_labels) if L == lab]
-            if not idxs:
-                continue
-            m = vecs[idxs].mean(axis=0)
-            m /= np.linalg.norm(m) + 1e-9
-            per[lab] = {"count": int(len(idxs)), "mean": m.tolist()}
-        stats = {
-            "count": int(vecs.shape[0]),
-            "dim": int(self._dim),
-            "labels": per,
-            "updated": _now_iso(),
-        }
-        self._save_json(self.stats_path, stats)
-
-    def _row_labels(self, n_rows: int) -> List[str]:
-        """
-        Build a dense row->label list from index.json.
-        """
-        lab = [""] * n_rows
-        for _rel, rec in self._index["items"].items():
-            r = int(rec["row"])
-            if 0 <= r < n_rows:
-                lab[r] = rec["label"]
-        return lab
-
-    def _harvest_raw_to_aligned(self) -> None:
-        """
-        For every gallery/<id>/raw/*.jpg, if there isn't a corresponding file
-        under gallery/<id>/aligned/, detect & align and save it.
-        """
-        if self.scrfd is None:
-            return
-
-        ids = self._iter_identities(self.gallery_dir)
-        if not ids:
-            return
-        for label, (aligned_dir, raw_dir) in ids:
-            if not osp.isdir(raw_dir):
-                continue
-            for p in list_images(raw_dir):
-                base = osp.splitext(osp.basename(p))[0]
-                tgt_dir = aligned_dir
-                _ensure_dir(tgt_dir)
-                tgt = osp.join(tgt_dir, f"{base}.jpg")
-                if osp.exists(tgt):
-                    continue  # already aligned once
-                img = cv2.imread(p)
-                if img is None or img.size == 0:
-                    continue
-                crop = _align_largest_face_bgr(
-                    img, self.scrfd, self.det_conf, self.aligned_size
+            embedding = np.asarray(embedding, dtype=np.float32).reshape(-1)
+            if embedding.shape[0] != self._dim:
+                # Caller gave a malformed vector — recompute defensively
+                log.warning(
+                    "add_sample: embedding shape %s, expected (%d,), re-embedding",
+                    embedding.shape,
+                    self._dim,
                 )
-                if crop is None:
-                    continue
-                cv2.imwrite(tgt, crop, [cv2.IMWRITE_JPEG_QUALITY, 95])
+                embedding = self.embed_aligned(crop)
+            else:
+                # Ensure L2-normalized (caller might have skipped)
+                embedding = _l2_normalize(embedding)
 
-    def _embed_new_aligned(self) -> Tuple[int, int]:
+        uuid_dir = osp.join(self.gallery_dir, uuid)
+        aligned_dir = osp.join(uuid_dir, "aligned")
+        _ensure_dir(aligned_dir)
+
+        # Pick a filename: ``sample_NNN.jpg`` keeps things sortable.
+        if fname_hint:
+            fname = fname_hint if fname_hint.endswith(".jpg") else f"{fname_hint}.jpg"
+        else:
+            fname = f"sample_{rec.sample_count + 1:04d}.jpg"
+
+        # Collision-safe filename. Compute stem ONCE from the original; the
+        # suffix counter keeps the chain `snap.jpg`, `snap_1.jpg`,
+        # `snap_2.jpg` instead of compounding as `snap_1_2.jpg`.
+        stem = fname.removesuffix(".jpg")
+        full_path = osp.join(aligned_dir, fname)
+        i = 0
+        while osp.exists(full_path):
+            i += 1
+            fname = f"{stem}_{i}.jpg"
+            full_path = osp.join(aligned_dir, fname)
+
+        # Write image (NB: this is not atomic — cv2.imwrite goes direct. A
+        # crash mid-write could leave a partial JPG. We accept this risk
+        # because (a) the embedding+centroid update happens after, so a
+        # half-JPG just orphans bytes, doesn't corrupt the gallery; (b)
+        # atomic JPG write would require a temp file dance for every sample.)
+        ok = cv2.imwrite(full_path, crop, [cv2.IMWRITE_JPEG_QUALITY, 95])
+        if not ok:
+            raise IOError(f"failed to write {full_path}")
+
+        # Append embedding to embeddings.npy
+        embeddings_path = osp.join(uuid_dir, "embeddings.npy")
+        if osp.exists(embeddings_path):
+            try:
+                prev = np.load(embeddings_path).astype(np.float32)
+            except Exception:
+                log.warning("UUID %s embeddings.npy corrupt; resetting", uuid)
+                prev = np.zeros((0, self._dim), dtype=np.float32)
+        else:
+            prev = np.zeros((0, self._dim), dtype=np.float32)
+        new_arr = np.vstack([prev, embedding[None, :]]).astype(np.float32)
+        _atomic_write_npy(embeddings_path, new_arr)
+
+        N_prev = prev.shape[0]
+        # Incremental centroid sum: new_sum = old_sum + embedding.
+        # We store the un-normalized sum so this stays exact under O(1).
+        # The L2-normalized form used for similarity is computed on the fly
+        # in get_centroids().
+        if rec.centroid_sum is not None and N_prev > 0:
+            new_sum = rec.centroid_sum + embedding
+        else:
+            new_sum = embedding.copy()
+        _atomic_write_npy(osp.join(uuid_dir, "centroid.npy"), new_sum)
+
+        # Update metadata
+        rec.metadata["sample_count"] = N_prev + 1
+        rec.metadata["updated_at"] = _now_iso()
+        _atomic_write_json(osp.join(uuid_dir, "metadata.json"), rec.metadata)
+
+        # Update in-memory record
+        rec.sample_count = N_prev + 1
+        rec.centroid_sum = new_sum
+
+        log.debug("add_sample: uuid=%s file=%s count=%d", uuid, fname, rec.sample_count)
+        return fname
+
+    def add_samples(
+        self,
+        uuid: str,
+        aligned_list: List[np.ndarray],
+        embeddings: Optional[List[np.ndarray]] = None,
+    ) -> List[str]:
+        """Batch-add multiple samples. More efficient than N add_sample calls
+        because the centroid + metadata are written once at the end.
+
+        ``embeddings`` may contain ``None`` entries for samples that need
+        re-embedding; pass a complete list with all entries valid for the
+        fast path.
         """
-        Scan aligned/ for images not in index; embed and append to vectors.
+        rec = self._records.get(uuid)
+        if rec is None:
+            raise KeyError(f"UUID not found: {uuid}")
+        if not aligned_list:
+            return []
 
-        Returns
-        -------
-        tuple[int, int]
-            ``(num_aligned_added, total_vectors_now)``.
+        # Normalize embeddings input
+        if embeddings is None:
+            embeddings = [None] * len(aligned_list)
+        if len(embeddings) != len(aligned_list):
+            raise ValueError("embeddings/aligned_list length mismatch")
+
+        uuid_dir = osp.join(self.gallery_dir, uuid)
+        aligned_dir = osp.join(uuid_dir, "aligned")
+        _ensure_dir(aligned_dir)
+
+        # Embed any missing vectors in a single batch
+        to_embed_idx = [i for i, e in enumerate(embeddings) if e is None]
+        if to_embed_idx:
+            crops_to_embed = [aligned_list[i] for i in to_embed_idx]
+            vecs = self.arc.infer(crops_to_embed)
+            for k, i in enumerate(to_embed_idx):
+                embeddings[i] = _l2_normalize(vecs[k])
+
+        # Validate / normalize provided embeddings
+        clean_embs: List[np.ndarray] = []
+        for e in embeddings:
+            e = np.asarray(e, dtype=np.float32).reshape(-1)
+            if e.shape[0] != self._dim:
+                raise ValueError(f"embedding shape {e.shape}, expected ({self._dim},)")
+            clean_embs.append(_l2_normalize(e))
+
+        # Write all crops
+        saved: List[str] = []
+        for k, (crop, emb) in enumerate(zip(aligned_list, clean_embs)):
+            if crop.shape[:2] != (self.aligned_size, self.aligned_size):
+                crop = cv2.resize(crop, (self.aligned_size, self.aligned_size))
+            fname = f"sample_{rec.sample_count + k + 1:04d}.jpg"
+            full_path = osp.join(aligned_dir, fname)
+            i = 0
+            while osp.exists(full_path):
+                i += 1
+                fname = f"sample_{rec.sample_count + k + 1:04d}_{i}.jpg"
+                full_path = osp.join(aligned_dir, fname)
+            ok = cv2.imwrite(full_path, crop, [cv2.IMWRITE_JPEG_QUALITY, 95])
+            if not ok:
+                raise IOError(f"failed to write {full_path}")
+            saved.append(fname)
+
+        # Embeddings: append all in one rewrite
+        embeddings_path = osp.join(uuid_dir, "embeddings.npy")
+        if osp.exists(embeddings_path):
+            try:
+                prev = np.load(embeddings_path).astype(np.float32)
+            except Exception:
+                prev = np.zeros((0, self._dim), dtype=np.float32)
+        else:
+            prev = np.zeros((0, self._dim), dtype=np.float32)
+        new_arr = np.vstack([prev] + [e[None, :] for e in clean_embs]).astype(
+            np.float32
+        )
+        _atomic_write_npy(embeddings_path, new_arr)
+
+        # Centroid sum: just add all new embeddings to the running sum.
+        # See IdentityRecord.centroid_sum for why we store un-normalized.
+        if rec.centroid_sum is not None and prev.shape[0] > 0:
+            new_sum = rec.centroid_sum.copy()
+        else:
+            new_sum = np.zeros(self._dim, dtype=np.float32)
+        for e in clean_embs:
+            new_sum = new_sum + e
+        _atomic_write_npy(osp.join(uuid_dir, "centroid.npy"), new_sum)
+
+        # Metadata
+        N = prev.shape[0] + len(clean_embs)
+        rec.metadata["sample_count"] = N
+        rec.metadata["updated_at"] = _now_iso()
+        _atomic_write_json(osp.join(uuid_dir, "metadata.json"), rec.metadata)
+
+        rec.sample_count = N
+        rec.centroid_sum = new_sum
+
+        log.info("add_samples: uuid=%s +%d (total=%d)", uuid, len(saved), N)
+        return saved
+
+    def set_name(self, uuid: str, name: str) -> None:
+        """Update the display name for a UUID. O(1), no GPU work.
+
+        Used by ``/set_name`` when the LLM learns who an auto-enrolled
+        identity actually is. The UUID never changes, so existing references
+        from face_tracker tracks remain valid.
         """
-        ids = self._iter_identities(self.gallery_dir)
-        if not ids:
-            return 0, 0
+        rec = self._records.get(uuid)
+        if rec is None:
+            raise KeyError(f"UUID not found: {uuid}")
 
-        new_paths: List[Tuple[str, str]] = []  # (label, rel_path)
-        for label, (aligned_dir, _raw_dir) in ids:
-            if not osp.isdir(aligned_dir):
-                continue
-            for ap in list_images(aligned_dir):
-                rel = osp.relpath(ap, self.gallery_dir).replace("\\", "/")
-                if rel in self._index["items"]:
-                    continue
-                new_paths.append((label, rel))
+        rec.name = name
+        rec.metadata["name"] = name
+        rec.metadata["updated_at"] = _now_iso()
+        _atomic_write_json(
+            osp.join(self.gallery_dir, uuid, "metadata.json"),
+            rec.metadata,
+        )
+        log.info("set_name: uuid=%s name=%r", uuid, name)
 
-        if not new_paths:
-            return 0, 0
+    def merge_into(self, source_uuid: str, target_uuid: str) -> int:
+        """Merge all samples from ``source_uuid`` into ``target_uuid``, then
+        delete the source. Returns the number of samples merged.
 
-        imgs: List[np.ndarray] = []
-        rels: List[str] = []
-        labels: List[str] = []
-        for label, rel in new_paths:
-            absf = osp.join(self.gallery_dir, rel)
-            img = cv2.imread(absf)
+        Use case: an anonymous auto-enrolled UUID turns out to be someone we
+        already know. Rather than carry two UUIDs for the same person (one
+        with front-face samples, one with side-face), fold them into one.
+        Recognition then matches the union of poses/angles.
+
+        Mechanics:
+          1. Read source's ``aligned/*.jpg`` crops.
+          2. Re-embed via AdaFace (cost: a few ms per crop).
+          3. ``add_samples(target, crops, embeddings)`` — updates centroid +
+             metadata atomically.
+          4. ``forget(source)`` — moves source to ``_trash/`` so the merge
+             is undoable for ~one delete cycle.
+
+        Raises
+        ------
+        KeyError
+            If either UUID isn't in the gallery.
+        """
+        src_rec = self._records.get(source_uuid)
+        tgt_rec = self._records.get(target_uuid)
+        if src_rec is None:
+            raise KeyError(f"source UUID not found: {source_uuid}")
+        if tgt_rec is None:
+            raise KeyError(f"target UUID not found: {target_uuid}")
+        if source_uuid == target_uuid:
+            return 0
+
+        # Read source's aligned crops from disk
+        aligned_dir = osp.join(self.gallery_dir, source_uuid, "aligned")
+        if not osp.isdir(aligned_dir):
+            log.warning("merge_into: source %s has no aligned/ dir", source_uuid)
+            self.forget(source_uuid)
+            return 0
+
+        files = sorted(f for f in os.listdir(aligned_dir) if f.endswith(".jpg"))
+        if not files:
+            log.warning("merge_into: source %s has no samples", source_uuid)
+            self.forget(source_uuid)
+            return 0
+
+        crops: List[np.ndarray] = []
+        for f in files:
+            path = osp.join(aligned_dir, f)
+            img = cv2.imread(path)
             if img is None:
+                log.warning("merge_into: skipping unreadable %s", path)
                 continue
             if img.shape[:2] != (self.aligned_size, self.aligned_size):
                 img = cv2.resize(img, (self.aligned_size, self.aligned_size))
-            imgs.append(img)
-            rels.append(rel)
-            labels.append(label)
+            crops.append(img)
 
-        if not imgs:
-            return 0, 0
+        if not crops:
+            log.warning("merge_into: no readable crops in source %s", source_uuid)
+            self.forget(source_uuid)
+            return 0
 
-        # >>> respect TensorRT optimization profile (e.g., max batch = 4)
-        feats = self._embed_batch(imgs)
-        norms = np.linalg.norm(feats, axis=1, keepdims=True) + 1e-9
-        feats = (feats / norms).astype(np.float32)
+        # add_samples re-embeds (when embeddings=None) and updates target centroid
+        saved = self.add_samples(target_uuid, crops, embeddings=None)
 
-        start_row = self._append_vectors(feats)
-        for i, rel in enumerate(rels):
-            self._index["items"][rel] = {"row": int(start_row + i), "label": labels[i]}
-        self._save_index()
+        # Soft-delete source (still in _trash if user wants to undo)
+        self.forget(source_uuid)
 
         log.info(
-            "gallery: appended %d vectors (total now: %d)",
-            feats.shape[0],
-            start_row + feats.shape[0],
+            "merge_into: %d samples from %s → %s",
+            len(saved),
+            source_uuid,
+            target_uuid,
         )
-        return len(rels), feats.shape[0]
+        return len(saved)
+
+    def forget(self, uuid: str) -> bool:
+        """Soft-delete: move UUID folder to ``_trash/``. O(1) filesystem op.
+
+        Returns True if removed, False if UUID didn't exist. Use ``restore``
+        to undo, or ``hard_delete`` / ``empty_trash`` to commit permanently.
+        """
+        if uuid not in self._records:
+            return False
+        src = osp.join(self.gallery_dir, uuid)
+        if not osp.isdir(src):
+            self._records.pop(uuid, None)
+            return False
+        dst_root = osp.join(self.gallery_dir, "_trash")
+        _ensure_dir(dst_root)
+        # If a trash entry with the same UUID already exists (shouldn't, but
+        # safe), suffix it with a timestamp.
+        dst = osp.join(dst_root, uuid)
+        if osp.exists(dst):
+            dst = osp.join(dst_root, f"{uuid}_{int(time.time())}")
+        shutil.move(src, dst)
+        self._records.pop(uuid, None)
+        log.info("forget: uuid=%s → _trash", uuid)
+        return True
+
+    def restore(self, uuid: str) -> bool:
+        """Move a UUID back from ``_trash/`` to active gallery.
+
+        Returns True on success, False if not found in trash.
+        """
+        src = osp.join(self.gallery_dir, "_trash", uuid)
+        if not osp.isdir(src):
+            return False
+        dst = osp.join(self.gallery_dir, uuid)
+        if osp.exists(dst):
+            log.warning("restore: uuid=%s already active; skipping", uuid)
+            return False
+        shutil.move(src, dst)
+        rec = self._load(uuid)
+        if rec is not None:
+            self._records[uuid] = rec
+        log.info("restore: uuid=%s ← _trash", uuid)
+        return True
+
+    def hard_delete(self, uuid: str) -> bool:
+        """Permanently delete a UUID from ``_trash/``. Returns True if removed.
+
+        Use ``forget`` first to move into trash, ``hard_delete`` to commit.
+        For "delete immediately" workflows, call both in sequence.
+        """
+        target = osp.join(self.gallery_dir, "_trash", uuid)
+        if osp.isdir(target):
+            shutil.rmtree(target)
+            log.info("hard_delete: uuid=%s removed from _trash", uuid)
+            return True
+        # If not in trash, check active (shouldn't happen unless caller skipped forget)
+        active = osp.join(self.gallery_dir, uuid)
+        if osp.isdir(active):
+            shutil.rmtree(active)
+            self._records.pop(uuid, None)
+            log.info("hard_delete: uuid=%s removed from active (skipped trash)", uuid)
+            return True
+        return False
+
+    def empty_trash(self) -> int:
+        """Delete everything in ``_trash/``. Returns number of UUIDs removed."""
+        trash = osp.join(self.gallery_dir, "_trash")
+        if not osp.isdir(trash):
+            return 0
+        count = 0
+        for entry in os.listdir(trash):
+            p = osp.join(trash, entry)
+            if osp.isdir(p):
+                shutil.rmtree(p)
+                count += 1
+        log.info("empty_trash: removed %d entries", count)
+        return count
+
+    # ==================================================================
+    # Embedding (passthrough to AdaFace)
+    # ==================================================================
 
     def embed_aligned(self, img_112_bgr: np.ndarray) -> np.ndarray:
-        """Embed a single aligned 112×112 BGR crop and L2-normalize the vector.
+        """Compute L2-normalized embedding for one aligned 112×112 BGR crop.
 
-        Public method used by:
-        - Internal save paths (``add_aligned_snapshot``, ``add_aligned_no_stats``)
-        - External callers (e.g. ``HttpAPI._handle_selfie``) for dedup,
-          consistency, and novelty checks — no disk I/O.
-
-        Parameters
-        ----------
-        img_112_bgr : np.ndarray
-            Aligned crop of shape ``(112,112,3)`` (will be resized if needed).
-
-        Returns
-        -------
-        np.ndarray
-            L2-normalized embedding of shape ``(dim,)`` with dtype float32.
+        Exposed publicly so HttpAPI can pre-compute embeddings during selfie
+        (for dedup) without writing to the gallery yet.
         """
         vec = self.arc.infer([img_112_bgr])
         if vec.ndim == 2 and vec.shape[0] == 1:
             vec = vec[0]
-        vec = vec.astype(np.float32, copy=False)
-        n = np.linalg.norm(vec) + 1e-9
-        return (vec / n).astype(np.float32, copy=False)
+        return _l2_normalize(vec.astype(np.float32, copy=False))
 
-    def _embed_batch(self, imgs_112_bgr: List[np.ndarray]) -> np.ndarray:
-        """Embed a list of aligned crops, chunked to respect AdaFace max batch.
+    # ==================================================================
+    # Migration from legacy gallery layout
+    # ==================================================================
 
-        Parameters
-        ----------
-        imgs_112_bgr : list[np.ndarray]
-            List of aligned BGR crops, each ``(112,112,3)``.
+    def migrate_legacy(self, legacy_root: Optional[str] = None) -> int:
+        """One-shot migration from the old name-keyed layout.
 
-        Returns
-        -------
-        np.ndarray
-            Float32 array of shape ``(K, dim)`` containing raw (unnormalized) vectors.
-        """
-        if not imgs_112_bgr:
-            return np.empty((0, self._dim), np.float32)
-        # Use your shared helper (already used at runtime)
-        vecs = infer_arc_batched(self.arc, imgs_112_bgr, max_bs=self.arc_max_bs)
-        return np.asarray(vecs, dtype=np.float32)
+        Old layout:
+            <legacy_root>/<name>/aligned/*.jpg  (112x112 BGR)
+            <legacy_root>/<name>/raw/*.jpg      (optional, not migrated)
 
-    def _append_vectors(self, vecs: np.ndarray) -> int:
-        """Append embeddings to ``vectors.f32`` and return the starting row index.
+        For each old identity:
+          - Create a new UUID via :meth:`create` with the same name.
+          - Re-embed the aligned crops (one-time GPU cost) and add them via
+            :meth:`add_samples`.
+          - Move the original folder under ``_legacy/<name>/`` for safety.
 
         Parameters
         ----------
-        vecs : np.ndarray
-            Float32 array of shape ``(K, dim)`` to append.
+        legacy_root : str, optional
+            Directory containing the old format. Defaults to
+            ``self.gallery_dir`` — useful when migration is in-place (old
+            non-UUID folders sit alongside new UUID folders during migration).
 
         Returns
         -------
         int
-            Starting row index where the first appended vector was written.
-
-        Raises
-        ------
-        AssertionError
-            If ``vecs`` does not have shape ``(K, dim)``.
+            Number of identities migrated.
         """
-        assert (
-            vecs.ndim == 2 and vecs.shape[1] == self._dim
-        ), f"expected (K,{self._dim}) got {vecs.shape}"
-        prev_rows = 0
-        if osp.exists(self.vectors_path):
-            sz = osp.getsize(self.vectors_path)
-            prev_rows = sz // (4 * self._dim)
-        with open(self.vectors_path, "ab") as f:
-            vecs.astype(np.float32, copy=False).tofile(f)
-        return int(prev_rows)
+        if legacy_root is None:
+            legacy_root = self.gallery_dir
+        if not osp.isdir(legacy_root):
+            return 0
 
-    @staticmethod
-    def _iter_identities(gallery_root: str) -> List[Tuple[str, Tuple[str, str]]]:
-        """Enumerate identity folders and their aligned/raw subdirectories.
+        legacy_archive = osp.join(self.gallery_dir, "_legacy")
+        _ensure_dir(legacy_archive)
 
-        Parameters
-        ----------
-        gallery_root : str
-            Gallery root path.
-
-        Returns
-        -------
-        list[tuple[str, tuple[str, str]]]
-            Pairs of ``(label, (aligned_dir, raw_dir))`` for each identity folder.
-        """
-        out: List[Tuple[str, Tuple[str, str]]] = []
-        if not osp.isdir(gallery_root):
-            return out
-        for name in sorted(os.listdir(gallery_root)):
-            p = osp.join(gallery_root, name)
-            if not osp.isdir(p):
+        migrated = 0
+        for entry in os.listdir(legacy_root):
+            if entry in _RESERVED_DIRS or _is_uuid_dir(entry):
                 continue
-            aligned_dir = osp.join(p, "aligned")
-            raw_dir = osp.join(p, "raw")
-            out.append((name, (aligned_dir, raw_dir)))
-        return out
+            src = osp.join(legacy_root, entry)
+            if not osp.isdir(src):
+                continue
+            aligned_dir = osp.join(src, "aligned")
+            if not osp.isdir(aligned_dir):
+                log.info("migrate: skipping %s (no aligned/ dir)", entry)
+                continue
 
+            crops: List[np.ndarray] = []
+            for fn in sorted(os.listdir(aligned_dir)):
+                if not fn.lower().endswith((".jpg", ".jpeg", ".png")):
+                    continue
+                img = cv2.imread(osp.join(aligned_dir, fn))
+                if img is None or img.size == 0:
+                    continue
+                if img.shape[:2] != (self.aligned_size, self.aligned_size):
+                    img = cv2.resize(img, (self.aligned_size, self.aligned_size))
+                crops.append(img)
 
-def build_gallery_embeddings(
-    gallery_root: str, scrfd: TRTSCRFD, arc: TRTFaceRecognition, det_conf: float
-) -> Tuple[np.ndarray, List[str]]:
-    """
-    One-shot builder that returns per-identity means (old API).
-    It builds/refreshes an embed store under embeds/<model_sig>/ next to gallery/.
+            if not crops:
+                log.info("migrate: skipping %s (no usable crops)", entry)
+                continue
 
-    Parameters
-    ----------
-    gallery_root : str
-        Path to the gallery root.
-    scrfd : TRTSCRFD
-        SCRFD detector used for alignment.
-    arc : TRTFaceRecognition
-        AdaFace TensorRT wrapper used for embedding.
-    det_conf : float
-        Detection confidence threshold for alignment.
+            new_uuid = self.create(
+                name=entry,
+                source="migration",
+                migrated_from=entry,
+                migrated_at=_now_iso(),
+            )
+            # add_samples handles batched embedding + centroid in one pass
+            self.add_samples(new_uuid, crops, embeddings=None)
 
-    Returns
-    -------
-    tuple[np.ndarray, list[str]]
-        ``(means, labels)`` where ``means`` is ``(N_id, dim)`` float32 and L2-normalized.
-    """
-    embeds_root = osp.join(osp.dirname(osp.abspath(gallery_root)), "embeds")
-    gm = GalleryManager(
-        gallery_dir=gallery_root,
-        embeds_dir=embeds_root,
-        arc=arc,
-        scrfd=scrfd,
-        det_conf=det_conf,
-        arc_max_bs=4,  # safe default for your engine profile
-    )
-    gm.refresh(process_raw=True)
-    return gm.get_identity_means()
+            # Archive the original folder
+            dst = osp.join(legacy_archive, entry)
+            if osp.exists(dst):
+                dst = osp.join(legacy_archive, f"{entry}_{int(time.time())}")
+            shutil.move(src, dst)
+
+            migrated += 1
+            log.info("migrate: %s → %s (samples=%d)", entry, new_uuid, len(crops))
+
+        if migrated:
+            log.info("Migration complete: %d identities", migrated)
+        return migrated
+
+    def has_legacy_data(self) -> bool:
+        """Return True if ``gallery_dir`` contains old name-keyed folders."""
+        if not osp.isdir(self.gallery_dir):
+            return False
+        for entry in os.listdir(self.gallery_dir):
+            if entry in _RESERVED_DIRS or _is_uuid_dir(entry):
+                continue
+            p = osp.join(self.gallery_dir, entry)
+            if osp.isdir(p) and osp.isdir(osp.join(p, "aligned")):
+                return True
+        return False

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
@@ -315,7 +315,7 @@ class UUIDGallery:
         if osp.exists(centroid_path):
             try:
                 centroid_sum = np.load(centroid_path).astype(np.float32)
-                if centroid_sum.shape != (self._dim,):
+                if centroid_sum is not None and centroid_sum.shape != (self._dim,):
                     log.warning(
                         "UUID %s centroid shape %s, expected (%d,)",
                         uuid,
@@ -763,9 +763,11 @@ class UUIDGallery:
             return []
 
         # Normalize embeddings input
-        if embeddings is None:
-            embeddings = [None] * len(aligned_list)
-        if len(embeddings) != len(aligned_list):
+        emb_list: List[Optional[np.ndarray]] = (
+            list(embeddings) if embeddings is not None
+            else [None] * len(aligned_list)
+        )
+        if len(emb_list) != len(aligned_list):
             raise ValueError("embeddings/aligned_list length mismatch")
 
         uuid_dir = osp.join(self.gallery_dir, uuid)
@@ -773,20 +775,20 @@ class UUIDGallery:
         _ensure_dir(aligned_dir)
 
         # Embed any missing vectors in a single batch
-        to_embed_idx = [i for i, e in enumerate(embeddings) if e is None]
+        to_embed_idx = [i for i, e in enumerate(emb_list) if e is None]
         if to_embed_idx:
             crops_to_embed = [aligned_list[i] for i in to_embed_idx]
             vecs = self.arc.infer(crops_to_embed)
             for k, i in enumerate(to_embed_idx):
-                embeddings[i] = _l2_normalize(vecs[k])
+                emb_list[i] = _l2_normalize(vecs[k])
 
         # Validate / normalize provided embeddings
         clean_embs: List[np.ndarray] = []
-        for e in embeddings:
-            e = np.asarray(e, dtype=np.float32).reshape(-1)
-            if e.shape[0] != self._dim:
-                raise ValueError(f"embedding shape {e.shape}, expected ({self._dim},)")
-            clean_embs.append(_l2_normalize(e))
+        for e in emb_list:
+            v = np.asarray(e, dtype=np.float32).reshape(-1)
+            if v.shape[0] != self._dim:
+                raise ValueError(f"embedding shape {v.shape}, expected ({self._dim},)")
+            clean_embs.append(_l2_normalize(v))
 
         # Write all crops
         saved: List[str] = []

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
@@ -214,11 +214,35 @@ class UUIDGallery:
         *,
         arc: TRTFaceRecognition,
         aligned_size: int = 112,
+        max_samples_per_uuid: int = 50,
+        last_seen_persist_interval_sec: float = 60.0,
     ) -> None:
         self.gallery_dir = osp.abspath(gallery_dir)
         self.arc = arc
         self.aligned_size = int(aligned_size)
         self._dim = int(getattr(arc, "embedding_dim", 512))
+        # FIFO cap per UUID. When add_sample would push past this, the
+        # oldest sample (lexicographically first JPG, row 0 of embeddings.npy)
+        # is evicted: file removed, embedding subtracted from centroid_sum,
+        # row 0 of embeddings.npy dropped. Keeps disk bounded as the system
+        # accumulates samples over long-running deployments and from the
+        # continuous-refresh path.
+        self.max_samples_per_uuid = int(max_samples_per_uuid)
+
+        # touch_last_seen is called every confident-recognition frame
+        # (~15 Hz × N visible faces). Writing metadata.json that often
+        # would dominate disk I/O. Instead, we maintain a two-layer
+        # cache: rec.metadata["last_seen_at"] is updated in memory on
+        # every call (cheap), and metadata.json is flushed to disk at
+        # most once per this many seconds per UUID. The disk lag is
+        # bounded; if the process crashes, we lose at most this many
+        # seconds of last_seen accuracy — fine for the /gallery/sweep_stale
+        # use case (cleanup thresholds are typically days/months).
+        self.last_seen_persist_interval_sec = float(last_seen_persist_interval_sec)
+        # Per-UUID monotonic timestamp of the most recent metadata.json
+        # write triggered by touch_last_seen. Used to enforce the
+        # rate-limit above.
+        self._last_seen_disk_ts: Dict[str, float] = {}
 
         _ensure_dir(self.gallery_dir)
         _ensure_dir(osp.join(self.gallery_dir, "_trash"))
@@ -239,6 +263,8 @@ class UUIDGallery:
         modifications to ``gallery_dir`` (e.g. file-level rsync).
         """
         self._records.clear()
+        self._last_seen_disk_ts.clear()
+        now_mono = time.monotonic()
         if not osp.isdir(self.gallery_dir):
             return 0
         for entry in os.listdir(self.gallery_dir):
@@ -258,6 +284,12 @@ class UUIDGallery:
                 rec = self._load(entry)
                 if rec is not None:
                     self._records[entry] = rec
+                    # Seed the rate-limit tracker: the file on disk is
+                    # current at load time, so touch_last_seen shouldn't
+                    # immediately re-write it. The first disk write for
+                    # this UUID won't happen until persist_interval seconds
+                    # have passed.
+                    self._last_seen_disk_ts[entry] = now_mono
             except Exception as e:
                 log.warning("Failed to load UUID %s: %s", entry, e)
         log.info("Gallery loaded: %d UUIDs", len(self._records))
@@ -446,8 +478,139 @@ class UUIDGallery:
             centroid_sum=None,
             metadata=meta,
         )
+        # We just wrote metadata.json — seed the touch_last_seen rate-
+        # limit tracker so the first touch within persist_interval seconds
+        # doesn't immediately re-write.
+        self._last_seen_disk_ts[u] = time.monotonic()
         log.info("Created UUID %s (name=%r, source=%s)", u, name, source)
         return u
+
+    def _evict_oldest_sample(self, uuid: str) -> bool:
+        """Drop the oldest sample (lexicographically first JPG) and the
+        matching row in embeddings.npy; subtract from centroid_sum.
+
+        Used internally by add_sample when max_samples_per_uuid would be
+        exceeded. Returns True if a sample was evicted, False if nothing
+        to evict (empty aligned/ or missing embeddings.npy).
+
+        Invariant: sorted file list 1:1 with embeddings.npy row order
+        (oldest first). add_sample maintains this by always appending.
+        Pre-named samples or odd numbering can break the invariant; in
+        that case eviction is best-effort and may slightly drift the
+        centroid — acceptable for a FIFO eviction strategy.
+        """
+        rec = self._records.get(uuid)
+        if rec is None:
+            return False
+        uuid_dir = osp.join(self.gallery_dir, uuid)
+        aligned_dir = osp.join(uuid_dir, "aligned")
+        if not osp.isdir(aligned_dir):
+            return False
+        files = sorted(f for f in os.listdir(aligned_dir) if f.endswith(".jpg"))
+        if not files:
+            return False
+
+        embeddings_path = osp.join(uuid_dir, "embeddings.npy")
+        if not osp.exists(embeddings_path):
+            # No embeddings file — can only delete the JPG.
+            try:
+                os.remove(osp.join(aligned_dir, files[0]))
+            except OSError as e:
+                log.warning("evict: failed to remove %s: %s", files[0], e)
+                return False
+            rec.sample_count = max(0, rec.sample_count - 1)
+            return True
+
+        try:
+            embeddings = np.load(embeddings_path).astype(np.float32)
+        except Exception as e:
+            log.warning("evict: embeddings.npy unreadable for %s: %s", uuid, e)
+            return False
+        if embeddings.shape[0] == 0:
+            return False
+
+        oldest_emb = embeddings[0]
+        # Subtract from centroid_sum (keep it consistent with remaining rows)
+        if rec.centroid_sum is not None:
+            rec.centroid_sum = (rec.centroid_sum - oldest_emb).astype(np.float32)
+
+        # Trim row 0
+        new_arr = embeddings[1:].astype(np.float32)
+        _atomic_write_npy(embeddings_path, new_arr)
+        if rec.centroid_sum is not None:
+            _atomic_write_npy(osp.join(uuid_dir, "centroid.npy"), rec.centroid_sum)
+
+        # Delete the file
+        try:
+            os.remove(osp.join(aligned_dir, files[0]))
+        except OSError as e:
+            log.warning("evict: failed to remove %s: %s", files[0], e)
+
+        rec.sample_count = max(0, rec.sample_count - 1)
+        log.debug(
+            "evict: uuid=%s dropped %s (count→%d)", uuid, files[0], rec.sample_count
+        )
+        return True
+
+    def touch_last_seen(self, uuid: str, ts_iso: Optional[str] = None) -> bool:
+        """Update ``metadata.last_seen_at`` without adding a sample. O(1)
+        in the hot path; disk I/O is rate-limited.
+
+        Two-layer cache (see ``last_seen_persist_interval_sec`` on
+        ``__init__``):
+          - In-memory ``rec.metadata["last_seen_at"]`` is updated on
+            every call (cheap, no I/O).
+          - ``metadata.json`` on disk is written at most once per
+            ``last_seen_persist_interval_sec`` per UUID.
+
+        Called every confident-recognition frame, so without rate-
+        limiting this would write ~15×N times per second (where N is
+        the number of confidently-tracked faces). The rate limit
+        bounds disk churn while keeping the in-memory value fresh for
+        snapshots (e.g. session_last_seen_iso) and queries (e.g.
+        list_stale).
+
+        On process crash, the on-disk last_seen_at may lag the true
+        last sighting by up to ``last_seen_persist_interval_sec``.
+        That's acceptable for the long-term cleanup use case (sweep
+        thresholds are days/months).
+
+        Forced flush: pass an explicit ``ts_iso`` to bypass the rate
+        limit (e.g. test setup, graceful shutdown).
+
+        Returns True if updated (in memory at least), False if UUID
+        unknown.
+        """
+        rec = self._records.get(uuid)
+        if rec is None:
+            return False
+        forced = ts_iso is not None
+        if ts_iso is None:
+            ts_iso = _now_iso()
+
+        # MEMORY: always update. Snapshot consumers (session_last_seen_iso,
+        # list_stale) read this directly.
+        rec.metadata["last_seen_at"] = ts_iso
+
+        # DISK: rate-limit. Skip the write if we wrote recently for this
+        # UUID, unless the caller forced an explicit timestamp.
+        now_mono = time.monotonic()
+        last_persist = self._last_seen_disk_ts.get(uuid, 0.0)
+        if (
+            not forced
+            and (now_mono - last_persist) < self.last_seen_persist_interval_sec
+        ):
+            return True  # in-memory updated; disk skipped
+
+        # Write through
+        uuid_dir = osp.join(self.gallery_dir, uuid)
+        try:
+            _atomic_write_json(osp.join(uuid_dir, "metadata.json"), rec.metadata)
+            self._last_seen_disk_ts[uuid] = now_mono
+        except OSError as e:
+            log.warning("touch_last_seen: write failed for %s: %s", uuid, e)
+            return False
+        return True
 
     def add_sample(
         self,
@@ -461,19 +624,25 @@ class UUIDGallery:
 
         Steps
         -----
-        1. Compute embedding if not provided (GPU work).
-        2. Write JPG to ``aligned/``.
-        3. Append the embedding to ``embeddings.npy`` (full rewrite, since
-           numpy lacks streaming append for ``.npy`` format — but it's still
-           cheap, embeddings are ~2KB per row).
-        4. Update centroid incrementally: ``new = norm((old*N + emb))``.
-        5. Update metadata.sample_count and updated_at.
+        1. If at ``max_samples_per_uuid`` cap, evict the oldest sample
+           (FIFO: oldest JPG removed, row 0 of embeddings.npy dropped,
+           subtract its contribution from centroid_sum).
+        2. Compute embedding if not provided (GPU work).
+        3. Write JPG to ``aligned/``.
+        4. Append the embedding to ``embeddings.npy``.
+        5. Update centroid incrementally: ``new = old_sum + embedding``.
+        6. Update metadata.sample_count, updated_at, and last_seen_at.
 
         Returns the filename of the saved sample (e.g. ``"sample_004.jpg"``).
         """
         rec = self._records.get(uuid)
         if rec is None:
             raise KeyError(f"UUID not found: {uuid}")
+
+        # 1. Enforce cap. If at limit, evict oldest before adding new so
+        # sample_count never exceeds max_samples_per_uuid.
+        if rec.sample_count >= self.max_samples_per_uuid:
+            self._evict_oldest_sample(uuid)
 
         # Normalize/validate the crop
         if aligned_112_bgr is None or aligned_112_bgr.size == 0:
@@ -504,6 +673,9 @@ class UUIDGallery:
         _ensure_dir(aligned_dir)
 
         # Pick a filename: ``sample_NNN.jpg`` keeps things sortable.
+        # NOTE: with eviction, sample_count can be less than the highest
+        # numeric suffix on disk. We base the new filename on the current
+        # count + 1, with collision suffixing to avoid clobbering.
         if fname_hint:
             fname = fname_hint if fname_hint.endswith(".jpg") else f"{fname_hint}.jpg"
         else:
@@ -555,8 +727,14 @@ class UUIDGallery:
 
         # Update metadata
         rec.metadata["sample_count"] = N_prev + 1
-        rec.metadata["updated_at"] = _now_iso()
+        now_iso = _now_iso()
+        rec.metadata["updated_at"] = now_iso
+        rec.metadata["last_seen_at"] = now_iso
         _atomic_write_json(osp.join(uuid_dir, "metadata.json"), rec.metadata)
+        # We just persisted last_seen_at as a side effect of the
+        # sample add. Reset touch_last_seen's rate-limit tracker so
+        # subsequent touches don't re-write for another full interval.
+        self._last_seen_disk_ts[uuid] = time.monotonic()
 
         # Update in-memory record
         rec.sample_count = N_prev + 1
@@ -654,13 +832,35 @@ class UUIDGallery:
         # Metadata
         N = prev.shape[0] + len(clean_embs)
         rec.metadata["sample_count"] = N
-        rec.metadata["updated_at"] = _now_iso()
+        now_iso = _now_iso()
+        rec.metadata["updated_at"] = now_iso
+        rec.metadata["last_seen_at"] = now_iso
         _atomic_write_json(osp.join(uuid_dir, "metadata.json"), rec.metadata)
+        # Reset rate-limit tracker (see add_sample for rationale)
+        self._last_seen_disk_ts[uuid] = time.monotonic()
 
         rec.sample_count = N
         rec.centroid_sum = new_sum
 
-        log.info("add_samples: uuid=%s +%d (total=%d)", uuid, len(saved), N)
+        # Enforce max cap (may have exceeded during batch / merge)
+        evicted_total = 0
+        while rec.sample_count > self.max_samples_per_uuid:
+            if not self._evict_oldest_sample(uuid):
+                break
+            evicted_total += 1
+        if evicted_total > 0:
+            # Persist final count after eviction
+            rec.metadata["sample_count"] = rec.sample_count
+            _atomic_write_json(osp.join(uuid_dir, "metadata.json"), rec.metadata)
+            log.info(
+                "add_samples: evicted %d oldest to enforce cap=%d",
+                evicted_total,
+                self.max_samples_per_uuid,
+            )
+
+        log.info(
+            "add_samples: uuid=%s +%d (total=%d)", uuid, len(saved), rec.sample_count
+        )
         return saved
 
     def set_name(self, uuid: str, name: str) -> None:
@@ -756,6 +956,112 @@ class UUIDGallery:
             target_uuid,
         )
         return len(saved)
+
+    def refresh_sample(
+        self,
+        uuid: str,
+        aligned_112_bgr: np.ndarray,
+        embedding: np.ndarray,
+        *,
+        min_diversity_sim: float = 0.65,
+        max_diversity_sim: float = 0.92,
+    ) -> bool:
+        """Continuously enrich a known UUID with a fresh sample, if it adds
+        new feature diversity to the existing centroid.
+
+        Guards (Guard C in the design):
+          - new sample's sim to centroid must be in
+            ``[min_diversity_sim, max_diversity_sim]``:
+            too high → near-duplicate, no info gain.
+            too low  → probably misidentified, would pollute centroid.
+          - upstream Guards A (sim_thr+0.1) and B (per-UUID rate limit) are
+            the caller's responsibility; they need context this method
+            doesn't have (per-track sim, last-refresh timestamps).
+
+        On a passing refresh:
+          - Sample is added via :meth:`add_sample` (which enforces the
+            ``max_samples_per_uuid`` cap and updates ``last_seen_at``).
+          - Returns True.
+
+        On a failed guard:
+          - Returns False. Caller may still want to ``touch_last_seen`` to
+            mark this UUID active (this method does NOT touch on failure
+            because the call wasn't a fresh observation, just a check).
+        """
+        rec = self._records.get(uuid)
+        if rec is None:
+            return False
+        if rec.centroid_normalized is None:
+            # No centroid yet — fall through to plain add_sample
+            self.add_sample(uuid, aligned_112_bgr, embedding=embedding)
+            return True
+
+        # Compute sim to current centroid
+        emb = np.asarray(embedding, dtype=np.float32).reshape(-1)
+        if emb.shape[0] != self._dim:
+            return False
+        emb = _l2_normalize(emb)
+        sim = float(emb @ rec.centroid_normalized)
+
+        if sim < min_diversity_sim:
+            log.debug(
+                "refresh_sample: uuid=%s SKIP sim=%.3f < min_diversity=%.3f "
+                "(likely misidentification)",
+                uuid,
+                sim,
+                min_diversity_sim,
+            )
+            return False
+        if sim > max_diversity_sim:
+            log.debug(
+                "refresh_sample: uuid=%s SKIP sim=%.3f > max_diversity=%.3f "
+                "(near-duplicate, no info gain)",
+                uuid,
+                sim,
+                max_diversity_sim,
+            )
+            return False
+
+        # Passed guards — add. add_sample handles cap enforcement and
+        # last_seen_at update.
+        self.add_sample(uuid, aligned_112_bgr, embedding=emb)
+        log.info(
+            "refresh_sample: uuid=%s ADDED sim=%.3f (count→%d)",
+            uuid,
+            sim,
+            rec.sample_count,
+        )
+        return True
+
+    def list_stale(self, max_age_sec: float) -> List[str]:
+        """Return UUIDs whose ``last_seen_at`` is older than ``max_age_sec``.
+
+        Used by long-term cleanup sweeps to identify identities that
+        haven't been observed recently and might be candidates for
+        soft-deletion. Caller decides whether to actually forget them.
+
+        UUIDs with no ``last_seen_at`` field (e.g. legacy or not yet
+        observed) are treated as stale.
+        """
+        if max_age_sec <= 0:
+            return []
+        cutoff = time.time() - max_age_sec
+        stale: List[str] = []
+        for uuid, rec in self._records.items():
+            ts_iso = rec.metadata.get("last_seen_at") or rec.metadata.get("created_at")
+            if not ts_iso:
+                stale.append(uuid)
+                continue
+            try:
+                # ISO format with optional 'Z' or offset
+                ts = time.mktime(time.strptime(ts_iso[:19], "%Y-%m-%dT%H:%M:%S"))
+            except (ValueError, TypeError):
+                # Unparsable → treat as stale (defensive)
+                stale.append(uuid)
+                continue
+            if ts < cutoff:
+                stale.append(uuid)
+        return stale
 
     def forget(self, uuid: str) -> bool:
         """Soft-delete: move UUID folder to ``_trash/``. O(1) filesystem op.

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/gallery.py
@@ -764,8 +764,7 @@ class UUIDGallery:
 
         # Normalize embeddings input
         emb_list: List[Optional[np.ndarray]] = (
-            list(embeddings) if embeddings is not None
-            else [None] * len(aligned_list)
+            list(embeddings) if embeddings is not None else [None] * len(aligned_list)
         )
         if len(emb_list) != len(aligned_list):
             raise ValueError("embeddings/aligned_list length mismatch")

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -32,6 +32,7 @@ from typing import Any, Callable, Dict, List, Optional
 import cv2
 import numpy as np
 
+from . import selfie_logic as sl
 from .adaface import warp_face_by_5p
 
 
@@ -102,6 +103,12 @@ class HttpAPI:
         self.log = logger or logging.getLogger("http_api")
         self.server = None
         self.face_tracker = face_tracker
+
+        # Selfie pipeline state
+        self.selfie_lock = threading.Lock()  # serialize concurrent /selfie
+        self.enrollment_lock = threading.Lock()  # protect last_enrollment dict
+        self.audit_lock = threading.Lock()  # serialize corrections.log writes
+        self.last_enrollment: Optional[Dict[str, Any]] = None
 
     def stop(self) -> None:
         """Stop an attached HTTP server if present."""
@@ -201,6 +208,12 @@ class HttpAPI:
 
             if path in ("/gallery/identities", "/gallery/list_identities"):
                 return self._handle_gallery_identities()
+
+            if path == "/gallery/move_samples":
+                return self._handle_gallery_move_samples(payload)
+
+            if path == "/gallery/forget_last":
+                return self._handle_gallery_forget_last(payload)
 
             return {"error": f"unknown path {path}"}
         except Exception as e:
@@ -373,72 +386,270 @@ class HttpAPI:
 
     def _handle_selfie(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """
-        Save a clean snapshot from the latest frame (no overlays) into ALIGNED ONLY,
-        and embed immediately (no RAW for selfie).
+        Multi-frame selfie enrollment with score-based target selection,
+        dedup, identity-consistency check, and adaptive sample count.
 
-        Parameters
-        ----------
-        payload: { "id": "alice" }
-
-        Returns
+        Payload
         -------
-        dict
-            { ok, saved_aligned, identities }
+        id    : str  (required) — requested identity name (lowercase, alnum/_/-)
+        force : bool (optional) — bypass cross-name reject (twins/lookalikes)
 
-        Notes
-        -----
-        Uses the cached `frame_state` (clean frame + dets/kpss) to create one
-        aligned 112×112 crop without invoking extra inference in the HTTP thread.
-        The embedding and centroid update are executed on the main thread via
-        `run_job_sync`.
+        Returns (success)
+        -----------------
+        { ok:True, id, merged, forced, samples_saved, match_sim, identities }
+
+        Errors
+        ------
+        bad_id | recognition_disabled | busy | no_valid_frames |
+        insufficient_samples | ambiguous_subjects | face_belongs_to
         """
         if not self.gm:
-            return {"error": "recognition disabled"}
-        if not payload or "id" not in payload:
-            return {"error": "missing 'id'"}
-        person = str(payload["id"])
+            return {"error": "recognition_disabled"}
 
-        # Use last clean frame & cached dets/kpss captured in the main loop.
-        with self.frame_lock:
-            frm = (
-                None
-                if self.frame_state.frame_bgr is None
-                else self.frame_state.frame_bgr.copy()
+        payload = payload or {}
+        requested = str(payload.get("id", "")).strip().lower()
+        ok, reason = sl.validate_identity_name(requested)
+        if not ok:
+            return {"error": "bad_id", "detail": reason}
+
+        force = bool(payload.get("force", False))
+
+        # Serialize concurrent /selfie calls — gallery + last_enrollment can't
+        # tolerate interleaved enrollment from two callers at once.
+        if not self.selfie_lock.acquire(blocking=False):
+            return {"error": "busy"}
+
+        try:
+            return self._do_selfie(requested, force)
+        finally:
+            self.selfie_lock.release()
+
+    def _do_selfie(self, requested: str, force: bool) -> Dict[str, Any]:
+        """Core selfie collection loop. Caller holds self.selfie_lock."""
+        # Snapshot cfg once so thresholds stay consistent for this request
+        with self.cfg_lock:
+            cfg_snap = dict(self.cfg)
+
+        window_sec = float(cfg_snap["selfie_window_sec"])
+        tap_interval = float(cfg_snap["selfie_tap_interval_sec"])
+        min_samples = int(cfg_snap["selfie_min_samples"])
+        max_samples = int(cfg_snap["selfie_max_samples"])
+        score_floor = float(cfg_snap["selfie_min_engagement"])
+        ambig_ratio = float(cfg_snap["selfie_ambiguity_ratio"])
+        novelty_thr = float(cfg_snap["selfie_novelty_thr"])
+        consist_thr = float(cfg_snap["selfie_consistency_thr"])
+
+        deadline = time.monotonic() + window_sec
+        crops: List[np.ndarray] = []
+        embs: List[np.ndarray] = []
+        running_mean: Optional[np.ndarray] = None
+        target_id: Optional[str] = None
+        merged_flag = False
+        match_label: Optional[str] = None
+        match_sim_seen = 0.0
+        ambiguity_streak = 0
+        last_seen_token = -1  # frame-change detection (see below)
+
+        # ----- Phase 2: Collection loop -----
+        while len(crops) < max_samples and time.monotonic() < deadline:
+            # (A) Snapshot frame_state under lock, release fast
+            with self.frame_lock:
+                if self.frame_state.frame_bgr is None:
+                    frm = None
+                    dets = kpss = None
+                    ts = 0.0
+                else:
+                    frm = self.frame_state.frame_bgr.copy()
+                    dets = (
+                        None
+                        if self.frame_state.dets is None
+                        else self.frame_state.dets.copy()
+                    )
+                    kpss = (
+                        None
+                        if self.frame_state.kpss is None
+                        else self.frame_state.kpss.copy()
+                    )
+                    ts = float(getattr(self.frame_state, "last_ts", 0.0))
+
+            # Prefer explicit last_ts if run.py is up-to-date. If it's 0.0
+            # (older run.py without the field), fall back to id(frm) — the
+            # array's memory address changes per .copy(), so consecutive
+            # snapshots produce distinct tokens.
+            frame_token = ts if ts > 0 else (id(frm) if frm is not None else 0)
+
+            if frm is None or frame_token == last_seen_token:
+                time.sleep(0.02)
+                continue
+            last_seen_token = frame_token
+
+            # (B) No detections this frame
+            if dets is None or len(dets) == 0:
+                continue
+
+            # (C) Score every face: (bbox_area / frame_area) * frontality
+            h, w = frm.shape[:2]
+            frame_area = float(h * w)
+            scores = [
+                sl.score_face(
+                    dets[i],
+                    kpss[i] if kpss is not None and i < len(kpss) else None,
+                    frame_area,
+                )
+                for i in range(len(dets))
+            ]
+
+            # (D) Ambiguity — fail fast on 2 consecutive ambiguous frames
+            is_amb, top_ratio = sl.check_ambiguity(scores, ambig_ratio, score_floor)
+            if is_amb:
+                ambiguity_streak += 1
+                if ambiguity_streak >= 2:
+                    self.log.info(
+                        "selfie ambiguous: ratio=%.3f n_engaged=%d",
+                        top_ratio,
+                        sum(1 for s in scores if s >= score_floor),
+                    )
+                    return {
+                        "error": "ambiguous_subjects",
+                        "top_ratio": round(top_ratio, 3),
+                        "n_engaged": sum(1 for s in scores if s >= score_floor),
+                    }
+                continue
+            ambiguity_streak = 0  # reset on any clean frame
+
+            # (E) Pick target & engagement floor
+            target_idx = int(np.argmax(scores))
+            if scores[target_idx] < score_floor:
+                continue
+
+            # (F) Need landmarks for alignment
+            if kpss is None or target_idx >= len(kpss):
+                continue
+            target_kps = kpss[target_idx]
+
+            # (G) Build aligned 112×112 crop + quality gate
+            crop = warp_face_by_5p(frm, target_kps, 112)
+            ok_q, q_reason = sl.quality_check(
+                crop, dets[target_idx], target_kps, cfg_snap
             )
-            dets = (
-                None if self.frame_state.dets is None else self.frame_state.dets.copy()
-            )
-            kpss = (
-                None if self.frame_state.kpss is None else self.frame_state.kpss.copy()
-            )
+            if not ok_q:
+                self.log.debug("selfie frame rejected: %s", q_reason)
+                continue
 
-        if frm is None or dets is None or dets.shape[0] == 0:
-            return {"error": "no recent frame/detections yet"}
-        if dets.shape[0] != 1:
-            return {"error": f"expect exactly 1 face, got {int(dets.shape[0])}"}
+            # (H) Embed on main thread (GPU)
+            v = self.run_job_sync(lambda c=crop: self.gm.embed_aligned(c))
 
-        # Build aligned crop ONCE (no new inference)
-        if kpss is not None:
-            crop = warp_face_by_5p(frm, kpss[0], 112)
-        else:
-            x1, y1, x2, y2, _ = dets[0].astype(int)
-            face = frm[max(0, y1) : max(0, y2), max(0, x1) : max(0, x2)]
-            crop = cv2.resize(face if face.size > 0 else frm, (112, 112))
+            # (I) First valid frame: dedup. Subsequent: consistency + novelty.
+            if target_id is None:
+                with self.gal_lock:
+                    feats = self.gal_state.gal_feats
+                    labels = list(self.gal_state.gal_labels)
 
-        ts = time.strftime("%Y-%m-%dT%H-%M-%S")
+                decision = sl.resolve_target_id(
+                    v,
+                    requested,
+                    feats,
+                    labels,
+                    cfg_snap,
+                    force=force,
+                )
 
-        def _do_add():
-            rel = self.gm.add_aligned_snapshot(person, crop, fname_hint=f"{ts}.jpg")
+                if decision.reject:
+                    self.log.info(
+                        "selfie face_belongs_to label=%s sim=%.3f",
+                        decision.match_label,
+                        decision.match_sim,
+                    )
+                    return {
+                        "error": "face_belongs_to",
+                        "name": decision.match_label,
+                        "sim": round(decision.match_sim, 3),
+                    }
+
+                target_id = decision.id
+                merged_flag = decision.merged
+                match_label = decision.match_label
+                match_sim_seen = decision.match_sim
+            else:
+                sim = sl.cosine_to_mean(running_mean, v)
+                if sim < consist_thr:
+                    # Different person showed up mid-window
+                    self.log.debug("selfie frame rejected: consistency=%.3f", sim)
+                    continue
+                if sim > novelty_thr:
+                    # Near-duplicate of what we've already collected
+                    self.log.debug("selfie frame rejected: not novel (sim=%.3f)", sim)
+                    continue
+
+            # (J) Accept the frame
+            crops.append(crop)
+            embs.append(v)
+            running_mean = sl.update_running_mean(running_mean, v, len(embs))
+            time.sleep(tap_interval)
+
+        # ----- Phase 3: Finalize -----
+        n = len(crops)
+        if n == 0:
+            return {"error": "no_valid_frames"}
+        if n < min_samples:
+            return {"error": "insufficient_samples", "got": n}
+
+        ts_str = time.strftime("%Y-%m-%dT%H-%M-%S")
+
+        # Single main-thread batch: save each crop with its pre-computed vec,
+        # then recompute stats ONCE, then snapshot centroids into gal_state.
+        def _do_save_batch():
+            saved = []
+            for k, (c, v) in enumerate(zip(crops, embs)):
+                rel = self.gm.add_aligned_no_stats(
+                    target_id,
+                    c,
+                    vec=v,
+                    fname_hint=f"{ts_str}_{k:02d}.jpg",
+                )
+                saved.append(rel)
+            self.gm.recompute_stats()
             feats, labels = self.gm.get_identity_means()
             with self.gal_lock:
-                self.gal_state.gal_feats, self.gal_state.gal_labels = feats, labels
-            return rel, len(labels)
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+            return saved, len(labels)
 
-        rel, n_id = self.run_job_sync(_do_add)
-        saved_aligned = os.path.join(
-            self.gallery_dir, rel
-        )  # absolute path for convenience
-        return {"ok": True, "saved_aligned": saved_aligned, "identities": int(n_id)}
+        saved_files, n_id = self.run_job_sync(_do_save_batch)
+
+        # Record for /gallery/move_samples and /gallery/forget_last
+        with self.enrollment_lock:
+            self.last_enrollment = {
+                "id": target_id,
+                "files": saved_files,
+                "monotonic_ts": time.monotonic(),
+                "wall_ts": time.time(),
+                "merged": merged_flag,
+                "forced": force,
+            }
+
+        if force:
+            self._audit_log(
+                f"selfie forced id={target_id} samples={n} "
+                f"matched={match_label or '-'} sim={match_sim_seen:.3f}"
+            )
+        else:
+            self.log.info(
+                "selfie ok id=%s merged=%s samples=%d",
+                target_id,
+                merged_flag,
+                n,
+            )
+
+        return {
+            "ok": True,
+            "id": target_id,
+            "merged": merged_flag,
+            "forced": force,
+            "samples_saved": n,
+            "match_sim": round(match_sim_seen, 3),
+            "identities": int(n_id),
+        }
 
     def _handle_gallery_delete(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Delete one or more identities and rebuild the embed store.
@@ -587,6 +798,263 @@ class HttpAPI:
             return {"ok": False, "error": str(e)}
 
         return {"ok": True, "total": len(identities), "identities": identities}
+
+    # -------------------- /gallery/move_samples --------------------- #
+    def _handle_gallery_move_samples(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Move samples from one identity to another.
+
+        Use cases:
+        - Rename (typo correction): to_id doesn't exist → folder is renamed.
+        - Merge into existing: to_id exists → samples merged in, from_id empty
+          folder deleted.
+
+        Payload
+        -------
+        from_id : str (required)
+        to_id   : str (required)
+        files   : List[str] (optional) — relative paths under gallery_dir.
+                  If omitted, uses last_enrollment.files (60s TTL; id must match).
+        """
+        if not self.gm:
+            return {"error": "recognition_disabled"}
+
+        payload = payload or {}
+        from_id = str(payload.get("from_id", "")).strip().lower()
+        to_id = str(payload.get("to_id", "")).strip().lower()
+
+        for label, name in (("from_id", from_id), ("to_id", to_id)):
+            ok, reason = sl.validate_identity_name(name)
+            if not ok:
+                return {"error": "bad_id", "detail": f"{label}: {reason}"}
+
+        if from_id == to_id:
+            return {"error": "same_id"}
+
+        payload_files = payload.get("files")
+        if payload_files:
+            files_to_move = [str(f) for f in payload_files]
+        else:
+            with self.enrollment_lock:
+                le = self.last_enrollment
+                if le is None or le["id"] != from_id:
+                    return {
+                        "error": "no_recent_enrollment",
+                        "detail": "supply files=[...] or call within 60s of /selfie",
+                    }
+                if time.monotonic() - le["monotonic_ts"] > 60.0:
+                    return {"error": "stale_enrollment"}
+                files_to_move = list(le["files"])
+
+        # Path traversal guard: every file must resolve to inside gallery_dir
+        safe_files = self._filter_safe_paths(files_to_move)
+        if not safe_files:
+            return {"error": "no_safe_files"}
+
+        t0 = time.monotonic()
+        moved, from_removed, n_id = self.run_job_sync(
+            lambda: self._do_move_samples(from_id, to_id, safe_files)
+        )
+
+        # Clear last_enrollment if we just consumed it
+        with self.enrollment_lock:
+            if (
+                self.last_enrollment is not None
+                and self.last_enrollment["id"] == from_id
+            ):
+                self.last_enrollment = None
+
+        return {
+            "ok": True,
+            "from_id": from_id,
+            "to_id": to_id,
+            "moved": int(moved),
+            "from_removed": bool(from_removed),
+            "identities": int(n_id),
+            "took_sec": round(time.monotonic() - t0, 3),
+        }
+
+    def _do_move_samples(
+        self, from_id: str, to_id: str, files: List[str]
+    ) -> "tuple[int, bool, int]":
+        """Main-thread worker. Returns (moved_count, from_removed, n_identities)."""
+        to_aligned = os.path.join(self.gallery_dir, to_id, "aligned")
+        os.makedirs(to_aligned, exist_ok=True)
+
+        moved = 0
+        for rel in files:
+            src = os.path.join(self.gallery_dir, rel)
+            if not os.path.isfile(src):
+                continue
+            fname = os.path.basename(rel)
+            dst = os.path.join(to_aligned, fname)
+            if os.path.exists(dst):
+                # Collision: append _moved<n> to disambiguate
+                base, ext = os.path.splitext(fname)
+                k = 1
+                while True:
+                    dst = os.path.join(to_aligned, f"{base}_moved{k}{ext}")
+                    if not os.path.exists(dst):
+                        break
+                    k += 1
+            shutil.move(src, dst)
+            moved += 1
+
+        from_removed = self._cleanup_empty_identity_dir(from_id)
+
+        # Rebuild from scratch — refresh() only adds, doesn't remove stale entries
+        self.gm.clear_and_rebuild()
+        feats, labels = self.gm.get_identity_means()
+        with self.gal_lock:
+            self.gal_state.gal_feats = feats
+            self.gal_state.gal_labels = labels
+
+        self._audit_log(
+            f"move {from_id}->{to_id} files={len(files)} moved={moved} "
+            f"from_removed={from_removed}"
+        )
+        return moved, from_removed, len(labels)
+
+    # -------------------- /gallery/forget_last --------------------- #
+    def _handle_gallery_forget_last(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Delete the samples saved by the most recent /selfie call.
+        Used when the wrong person was captured.
+
+        Payload (optional)
+        ------------------
+        id : str — if provided, must match last_enrollment.id (safety check)
+        """
+        if not self.gm:
+            return {"error": "recognition_disabled"}
+
+        payload = payload or {}
+
+        with self.enrollment_lock:
+            le = self.last_enrollment
+            if le is None:
+                return {"error": "no_recent_enrollment"}
+            if time.monotonic() - le["monotonic_ts"] > 60.0:
+                return {"error": "stale_enrollment"}
+
+            target_id = le["id"]
+            files = list(le["files"])
+
+            if "id" in payload:
+                requested = str(payload["id"]).strip().lower()
+                if requested != target_id:
+                    return {
+                        "error": "id_mismatch",
+                        "detail": f"last enrollment was {target_id}",
+                    }
+
+        safe_files = self._filter_safe_paths(files)
+        if not safe_files:
+            return {"error": "no_safe_files"}
+
+        t0 = time.monotonic()
+        deleted, identity_removed, n_id = self.run_job_sync(
+            lambda: self._do_forget_files(target_id, safe_files)
+        )
+
+        with self.enrollment_lock:
+            self.last_enrollment = None
+
+        return {
+            "ok": True,
+            "id": target_id,
+            "files_deleted": int(deleted),
+            "identity_removed": bool(identity_removed),
+            "identities": int(n_id),
+            "took_sec": round(time.monotonic() - t0, 3),
+        }
+
+    def _do_forget_files(
+        self, target_id: str, files: List[str]
+    ) -> "tuple[int, bool, int]":
+        """Main-thread worker for /gallery/forget_last."""
+        deleted = 0
+        for rel in files:
+            path = os.path.join(self.gallery_dir, rel)
+            if os.path.isfile(path):
+                try:
+                    os.remove(path)
+                    deleted += 1
+                except OSError as e:
+                    self.log.warning("failed to remove %s: %s", path, e)
+
+        identity_removed = self._cleanup_empty_identity_dir(target_id)
+
+        # Rebuild from scratch — refresh() leaves stale entries behind
+        self.gm.clear_and_rebuild()
+        feats, labels = self.gm.get_identity_means()
+        with self.gal_lock:
+            self.gal_state.gal_feats = feats
+            self.gal_state.gal_labels = labels
+
+        self._audit_log(
+            f"forget {target_id} files={len(files)} deleted={deleted} "
+            f"identity_removed={identity_removed}"
+        )
+        return deleted, identity_removed, len(labels)
+
+    # -------------------- helpers --------------------- #
+    def _filter_safe_paths(self, rel_paths: List[Any]) -> List[str]:
+        """
+        Return only the relative paths that resolve to inside gallery_dir.
+
+        Path-traversal guard for /gallery/move_samples (where `files` may
+        come from a payload). Rejects absolute paths, `../` escapes, and
+        anything pointing outside the gallery root.
+        """
+        safe: List[str] = []
+        base = os.path.abspath(self.gallery_dir) + os.sep
+        for rel in rel_paths:
+            if not isinstance(rel, str) or not rel:
+                continue
+            abs_path = os.path.abspath(os.path.join(self.gallery_dir, rel))
+            if not (abs_path + os.sep).startswith(base):
+                self.log.warning("rejecting path traversal attempt: %s", rel)
+                continue
+            safe.append(rel)
+        return safe
+
+    def _cleanup_empty_identity_dir(self, identity: str) -> bool:
+        """
+        Remove identity_dir and its empty subfolders. Returns True if removed.
+        Conservative: leaves the folder alone if anything (e.g. raw/*.jpg)
+        is still in it.
+        """
+        id_dir = os.path.join(self.gallery_dir, identity)
+        if not os.path.isdir(id_dir):
+            return False
+
+        for sub in ("aligned", "raw"):
+            sub_dir = os.path.join(id_dir, sub)
+            if os.path.isdir(sub_dir) and not os.listdir(sub_dir):
+                try:
+                    os.rmdir(sub_dir)
+                except OSError:
+                    pass
+
+        try:
+            if not os.listdir(id_dir):
+                os.rmdir(id_dir)
+                return True
+        except OSError:
+            pass
+        return False
+
+    def _audit_log(self, msg: str) -> None:
+        """Append a timestamped line to gallery_dir/corrections.log."""
+        log_path = os.path.join(self.gallery_dir, "corrections.log")
+        ts = time.strftime("%Y-%m-%dT%H:%M:%S")
+        try:
+            with self.audit_lock:
+                with open(log_path, "a") as f:
+                    f.write(f"{ts} {msg}\n")
+        except Exception as e:
+            self.log.warning("audit log failed: %s", e)
 
     @staticmethod
     def _load_112(

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -37,7 +37,7 @@ import logging
 import os.path as osp
 import threading
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import cv2
 import numpy as np
@@ -238,6 +238,12 @@ class HttpAPI:
                 return self._handle_gallery_merge(payload)
             if path == "/gallery/find_similar":
                 return self._handle_gallery_find_similar(payload)
+            if path == "/gallery/find_similar_current":
+                return self._handle_gallery_find_similar_current(payload)
+            if path == "/gallery/merge_current":
+                return self._handle_gallery_merge_current(payload)
+            if path == "/gallery/sweep_stale":
+                return self._handle_gallery_sweep_stale(payload)
 
             return {"error": f"unknown path {path}"}
         except Exception as e:
@@ -268,7 +274,65 @@ class HttpAPI:
             unknowns = self.frame_state.current_unknowns
 
         if self.face_tracker is not None:
-            result["faces"] = faces
+            # Decorate faces with metadata the LLM uses to choose its
+            # greeting style:
+            #
+            #   created_ago_sec    — how long ago was this UUID first
+            #                        added to the gallery. ("we've ever
+            #                        met")
+            #   last_seen_ago_sec  — gap (in seconds) between the
+            #                        PREVIOUS sighting of this UUID and
+            #                        the current track session start.
+            #                        Sticky: stays constant for the
+            #                        whole track session so the LLM's
+            #                        "newcomer / met before" judgment
+            #                        doesn't flip mid-conversation.
+            #   last_seen_iso      — the previous-sighting ISO timestamp
+            #                        itself (string), so the LLM can
+            #                        say "I last saw you on 2026-03-05".
+            #
+            # Unknown / no-UUID faces get None for all three.
+            now = time.time()
+            decorated_faces = []
+            for f in faces:
+                fc = dict(f)  # shallow copy so we don't mutate frame_state
+                uuid = fc.get("uuid")
+                created_ago_sec: Optional[float] = None
+                last_seen_ago_sec: Optional[float] = None
+                last_seen_iso: Optional[str] = fc.get("session_last_seen_iso")
+
+                if uuid and self.gallery is not None:
+                    rec = self.gallery.get_record(uuid)
+                    if rec is not None:
+                        ts_iso = rec.metadata.get("created_at")
+                        if ts_iso:
+                            try:
+                                ts = time.mktime(
+                                    time.strptime(ts_iso[:19], "%Y-%m-%dT%H:%M:%S")
+                                )
+                                created_ago_sec = max(0.0, now - ts)
+                            except (ValueError, TypeError):
+                                pass
+
+                # Compute last_seen_ago_sec from the sticky session value
+                # (NOT from gallery's current last_seen_at, which would
+                # always be ~0 for the visible face).
+                if last_seen_iso:
+                    try:
+                        ts = time.mktime(
+                            time.strptime(last_seen_iso[:19], "%Y-%m-%dT%H:%M:%S")
+                        )
+                        last_seen_ago_sec = max(0.0, now - ts)
+                    except (ValueError, TypeError):
+                        pass
+
+                fc["created_ago_sec"] = created_ago_sec
+                fc["last_seen_ago_sec"] = last_seen_ago_sec
+                fc["last_seen_iso"] = last_seen_iso
+                # Drop the internal field name — clients use last_seen_iso
+                fc.pop("session_last_seen_iso", None)
+                decorated_faces.append(fc)
+            result["faces"] = decorated_faces
             if unknowns:
                 result["unknown_captures"] = unknowns
 
@@ -1408,6 +1472,313 @@ class HttpAPI:
             "ok": True,
             "uuid": uuid,
             "matches": candidates,
+        }
+
+    # ==================================================================
+    # /gallery/find_similar_current — no-UUID variant for LLM ergonomics
+    # ==================================================================
+
+    def _get_current_largest_face_uuid(self) -> Optional[Dict[str, Any]]:
+        """Return ``{uuid, name, tier, area, track_id}`` for the most prominent
+        currently-visible face that has a UUID, or None.
+
+        "Most prominent" = largest bbox area (closest to camera). Faces
+        without a UUID (e.g. transient "unknown" still being recognized)
+        are skipped — they have no identity for the LLM to act on.
+
+        Acquires self.frame_lock for a consistent snapshot.
+        """
+        with self.frame_lock:
+            faces = list(self.frame_state.current_faces)
+
+        # current_faces is already sorted by area desc, but defensive
+        faces.sort(key=lambda f: f.get("area", 0), reverse=True)
+        for f in faces:
+            uuid = f.get("uuid")
+            if uuid:
+                return f
+        return None
+
+    def _handle_gallery_find_similar_current(
+        self, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Find similar UUIDs to the currently-largest visible face.
+
+        Wraps :meth:`_handle_gallery_find_similar` but resolves the query
+        UUID server-side from the visible scene rather than requiring
+        the LLM to pass one. This is the recommended entry point for
+        LLM-driven "do you remember me?" interactions.
+
+        Payload
+        -------
+        top_k    : int (optional, default 3)
+        min_sim  : float (optional, default 0.0)
+
+        Returns
+        -------
+        Either the find_similar response (with ``query_face`` describing
+        which face was used) or ``{"error": "no_visible_face"}``.
+        """
+        face = self._get_current_largest_face_uuid()
+        if face is None:
+            return {"error": "no_visible_face"}
+
+        # Delegate to the UUID-based handler. Echo back the query face
+        # info so the LLM (and Go connector) can log/display it.
+        sub_payload = dict(payload or {})
+        sub_payload["uuid"] = face["uuid"]
+        result = self._handle_gallery_find_similar(sub_payload)
+        if "ok" in result and result["ok"]:
+            result["query_face"] = {
+                "uuid": face.get("uuid"),
+                "name": face.get("name"),
+                "track_id": face.get("track_id"),
+                "tier": face.get("tier"),
+            }
+        return result
+
+    # ==================================================================
+    # /gallery/merge_current — no-UUID variant for LLM ergonomics
+    # ==================================================================
+
+    def _handle_gallery_merge_current(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge current visible face into the same-name UUID best matching it.
+
+        Server-side disambiguation: the LLM gives a target NAME (e.g.
+        "sean") and the server picks the source (current largest visible
+        face) and target (UUID with that name closest to the source by
+        centroid sim).
+
+        Workflow this enables (the LLM doesn't see any UUIDs)::
+
+            User: "Are you Sean?" → "Yes"
+            LLM: gallery_merge_current(target_name="sean", confirmed_by="user_voice")
+            Server picks source = current anon UUID + target = best "sean".
+
+        Payload
+        -------
+        target_name  : str (required)  — display name the visitor confirmed
+        confirmed_by : str (optional)  — audit string (e.g. "user_voice")
+        min_sim      : float (optional, default 0.0) — if multiple "sean"
+                       UUIDs exist, require best one's sim ≥ this to
+                       avoid merging into the wrong same-name UUID
+
+        Returns
+        -------
+        Same shape as /gallery/merge on success. New error codes:
+        - no_visible_face          — nothing on screen with a UUID
+        - source_is_named          — current face already has a name; the
+                                     LLM probably called this by mistake
+        - target_name_not_found    — no gallery UUID has that name
+        - ambiguous_target         — same-name UUIDs exist but best sim
+                                     is below min_sim (and N > 1)
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+
+        payload = payload or {}
+        target_name = str(payload.get("target_name", "")).strip().lower()
+        confirmed_by = str(payload.get("confirmed_by", "")).strip()
+        try:
+            min_sim = float(payload.get("min_sim", 0.0))
+        except (TypeError, ValueError):
+            return {"error": "bad_min_sim"}
+
+        if not target_name:
+            return {"error": "missing_target_name"}
+
+        # 1. Resolve source = current largest visible face with UUID
+        face = self._get_current_largest_face_uuid()
+        if face is None:
+            return {"error": "no_visible_face"}
+        source_uuid = face["uuid"]
+        source_name = face.get("name") or ""
+
+        # Defensive: if the visible face is already named, the LLM is
+        # probably confused (you don't merge a named face). Allow it
+        # only if the source name happens to equal target_name (no-op
+        # against the same-name UUID — fall through to no-op below).
+        if source_name and not source_name.startswith("anon_"):
+            if source_name.lower() != target_name:
+                return {
+                    "error": "source_is_named",
+                    "source_name": source_name,
+                    "detail": "current visible face is already named differently",
+                }
+
+        # 2. Resolve target: UUIDs with name == target_name, pick best sim
+        src_rec = self.gallery.get_record(source_uuid)
+        if src_rec is None:
+            return {"error": "uuid_not_found", "uuid": source_uuid, "role": "source"}
+        src_centroid = src_rec.centroid_normalized
+        if src_centroid is None:
+            return {"error": "no_centroid", "uuid": source_uuid, "role": "source"}
+
+        # Iterate active gallery for same-name candidates
+        same_name_uuids: List[Tuple[str, float, int]] = []
+        for rec_dict in self.gallery.list_identities(include_unnamed=False):
+            cand_uuid = rec_dict["uuid"]
+            if cand_uuid == source_uuid:
+                continue
+            if (rec_dict.get("name") or "").lower() != target_name:
+                continue
+            cand_rec = self.gallery.get_record(cand_uuid)
+            if cand_rec is None or cand_rec.centroid_normalized is None:
+                continue
+            sim = float(src_centroid @ cand_rec.centroid_normalized)
+            same_name_uuids.append((cand_uuid, sim, cand_rec.sample_count))
+
+        if not same_name_uuids:
+            return {"error": "target_name_not_found", "target_name": target_name}
+
+        # Sort by sim desc; best candidate first
+        same_name_uuids.sort(key=lambda t: t[1], reverse=True)
+        best_uuid, best_sim, _ = same_name_uuids[0]
+
+        # If there's more than one same-name UUID and the top sim is low,
+        # don't guess — surface ambiguity to caller.
+        if len(same_name_uuids) > 1 and best_sim < min_sim:
+            return {
+                "error": "ambiguous_target",
+                "target_name": target_name,
+                "candidates": [
+                    {"uuid": u, "sim": round(s, 3), "samples": c}
+                    for u, s, c in same_name_uuids[:5]
+                ],
+                "detail": (
+                    f"{len(same_name_uuids)} candidates for name {target_name!r}; "
+                    f"best sim {best_sim:.3f} < min_sim {min_sim:.3f}"
+                ),
+            }
+
+        # 3. Delegate to the standard merge handler with resolved UUIDs.
+        # Compose a richer audit string so the log shows what was picked.
+        audit = (
+            f"{confirmed_by or '<unspecified>'}; "
+            f"resolved via merge_current target_name={target_name} "
+            f"best_sim={best_sim:.3f}"
+        )
+        sub_payload = {
+            "source_uuid": source_uuid,
+            "target_uuid": best_uuid,
+            "confirmed_by": audit,
+        }
+        result = self._handle_gallery_merge(sub_payload)
+        # Annotate result with the resolution info the LLM/Go side
+        # might want to surface to the user.
+        if isinstance(result, dict) and result.get("ok"):
+            result["target_name"] = target_name
+            result["resolved_by"] = "merge_current"
+        return result
+
+    # ==================================================================
+    # /gallery/sweep_stale — long-term cleanup
+    # ==================================================================
+
+    def _handle_gallery_sweep_stale(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Identify (and optionally soft-delete) UUIDs not seen recently.
+
+        For long-running deployments where the gallery accumulates many
+        identities — especially anon UUIDs from passers-by who never
+        introduced themselves. Disk math: 50 samples × ~50KB = 2.5MB
+        per UUID, so 1000 unused UUIDs = 2.5GB. This endpoint lets the
+        operator (or a cron job) reclaim space.
+
+        Payload
+        -------
+        max_age_sec   : float (required) — UUIDs with last_seen_at older
+                                           than this many seconds become
+                                           candidates. E.g. 30 days =
+                                           2_592_000.
+        dry_run       : bool (default True) — if True, list candidates
+                                              without deleting. Set
+                                              False to actually move
+                                              them to _trash.
+        protect_named : bool (default True) — if True, skip UUIDs that
+                                              have been named (only sweep
+                                              anon_xxx). Strong default;
+                                              cleaning up a named
+                                              identity by accident is
+                                              hard to recover from.
+
+        Returns
+        -------
+        ok           : bool
+        dry_run      : bool
+        candidates   : list of {uuid, name, last_seen_at, sample_count,
+                                action: "deleted"|"would_delete"|"skipped_named"}
+        deleted      : int — number actually soft-deleted (0 if dry_run)
+        identities   : int — total active gallery size after sweep
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+
+        payload = payload or {}
+        try:
+            max_age_sec = float(payload.get("max_age_sec", 0))
+        except (TypeError, ValueError):
+            return {"error": "bad_max_age_sec"}
+        if max_age_sec <= 0:
+            return {
+                "error": "bad_max_age_sec",
+                "detail": "max_age_sec must be > 0",
+            }
+        dry_run = bool(payload.get("dry_run", True))
+        protect_named = bool(payload.get("protect_named", True))
+
+        stale_uuids = self.gallery.list_stale(max_age_sec)
+        candidates: List[Dict[str, Any]] = []
+        deleted = 0
+
+        for uuid in stale_uuids:
+            rec = self.gallery.get_record(uuid)
+            if rec is None:
+                continue
+            entry = {
+                "uuid": uuid,
+                "name": rec.name,
+                "last_seen_at": rec.metadata.get("last_seen_at"),
+                "sample_count": rec.sample_count,
+            }
+            # Skip named identities if protect_named is set
+            if protect_named and rec.name and not rec.name.startswith("anon_"):
+                entry["action"] = "skipped_named"
+                candidates.append(entry)
+                continue
+            if dry_run:
+                entry["action"] = "would_delete"
+            else:
+                # Actual soft-delete via gallery.forget (moves to _trash)
+                ok = self.gallery.forget(uuid)
+                if ok:
+                    deleted += 1
+                    entry["action"] = "deleted"
+                else:
+                    entry["action"] = "delete_failed"
+            candidates.append(entry)
+
+        # Refresh in-memory gallery snapshot used by recognition
+        if not dry_run and deleted > 0:
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+
+        self._audit_log(
+            f"gallery_sweep_stale max_age={max_age_sec:.0f}s "
+            f"dry_run={dry_run} protect_named={protect_named} "
+            f"candidates={len(candidates)} deleted={deleted}"
+        )
+
+        return {
+            "ok": True,
+            "dry_run": dry_run,
+            "protect_named": protect_named,
+            "max_age_sec": max_age_sec,
+            "candidates": candidates,
+            "deleted": deleted,
+            "identities": len(self.gallery.list_identities(include_unnamed=True)),
         }
 
     # ==================================================================

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -132,7 +132,7 @@ class HttpAPI:
         gallery_dir: str,
         gal_state,
         gal_lock: threading.Lock,
-        cfg: Dict[str, object],
+        cfg: Dict[str, Any],
         cfg_lock: threading.Lock,
         frame_state,
         frame_lock: threading.Lock,
@@ -803,6 +803,7 @@ class HttpAPI:
                 # Consistency + novelty against running_mean. running_mean
                 # is guaranteed non-None here because we set it in the
                 # previous iteration before bumping `resolved`.
+                assert running_mean is not None
                 sim = sl.cosine_to_mean(running_mean, v)
                 if sim < consist_thr:
                     _bump("consistency_fail")

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -1,30 +1,40 @@
 #!/usr/bin/env python3
 """
-HTTP control plane for the realtime face pipeline.
+HTTP control plane for the realtime face pipeline (UUID-keyed gallery).
 
 This module exposes a thin, thread-safe HTTP API that lets external tools
-query presence (/who), adjust runtime configuration (/config), and manage the
-face gallery (/gallery/refresh, /gallery/add_aligned, /gallery/add_raw, /selfie)
-while the main video loop keeps running.
+query presence (/who), tweak runtime configuration (/config), and manage the
+face gallery (/gallery/refresh, /gallery/add_aligned, /gallery/add_raw,
+/selfie, /set_name, /gallery/forget_last, /gallery/restore,
+/gallery/delete, /gallery/identities, /gallery/auto_enroll_status,
+/gallery/merge, /gallery/find_similar) while the main video loop keeps
+running.
 
-Notes
------
-- The HTTP server runs on its own thread. Handlers in this module never call
-  CUDA/TensorRT directly; instead they use `run_job_sync(fn)` to enqueue work
-  onto the main thread's job queue so GPU/model operations are serialized.
-- Shared state (config, gallery embeddings/labels, last clean frame) is protected
-  by locks supplied by the caller.
-- This class does not bind a socket by itself; the caller typically registers
-  `HttpAPI._handle` with a lightweight `Server` instance.
+Identity model
+--------------
+Identities are referenced by UUID (32-char hex). Display names are mutable
+metadata; two UUIDs may share the same name (e.g. one auto-enrolled and one
+selfie-enrolled instance of the same person). All write endpoints that
+target a single identity accept ``uuid`` as the primary parameter. Legacy
+endpoints that took ``id``/``name`` resolve via ``gallery.find_by_name``
+when the matching UUID isn't given.
+
+Thread / GPU model
+------------------
+- HTTP server runs on its own thread. Handlers never call CUDA/TensorRT
+  directly; instead they use ``run_job_sync(fn)`` to enqueue work onto the
+  main thread's job queue so GPU/TensorRT operations are serialized.
+- Shared state (config, gallery, in-memory centroids, last clean frame) is
+  protected by locks supplied by the caller.
+- The ``UUIDGallery`` and ``AutoEnroller`` instances assume single-thread
+  access — all writes to them must go through ``run_job_sync``.
 """
 
 from __future__ import annotations
 
 import base64
 import logging
-import os
 import os.path as osp
-import shutil
 import threading
 import time
 from typing import Any, Callable, Dict, List, Optional
@@ -35,40 +45,81 @@ import numpy as np
 from . import selfie_logic as sl
 from .adaface import warp_face_by_5p
 
+logger = logging.getLogger(__name__)
+
+
+# Human-readable hint for why selfie failed, based on which reason dominated.
+# Maps the top-1 rejection reason to actionable user advice. Used in the
+# /selfie response so the LLM (or human debugger) knows what to tell the user.
+_SELFIE_HINT_MAP = {
+    "no_face_detected": "No face seen in the frame. Stand in front of the camera.",
+    "not_engaged": "Face is too small or not facing the camera. Walk closer and face the camera directly.",
+    "ambiguous_faces": "Multiple people in frame at similar distance. Step forward so you're clearly the closest.",
+    "empty_bbox": "Detection box was invalid (likely edge of frame). Center yourself in the frame.",
+    "too_small": "Face is too small in the frame. Walk closer to the camera.",
+    "low_conf": "Detector isn't confident this is a face. Improve lighting or get closer.",
+    "bad_pose": "Face is too turned. Look at the camera directly.",
+    "blurry": "Image is blurry. Hold still or improve lighting.",
+    "too_dark": "Frame is too dark. Improve lighting.",
+    "too_bright": "Frame is overexposed. Reduce backlight / strong light source.",
+    "consistency_fail": "Frames look like different people mid-window. Hold still.",
+    "novelty_fail": "All frames look identical (frozen feed?). Move slightly.",
+    "quality_fail": "Generic quality check failure.",
+}
+
+
+def _selfie_hint(reasons: Dict[str, int]) -> str:
+    """Return the actionable hint for the most-frequent rejection reason."""
+    if not reasons:
+        return "No frames were inspected. Camera may be stalled."
+    top_reason = max(reasons.items(), key=lambda kv: kv[1])[0]
+    return _SELFIE_HINT_MAP.get(top_reason, f"Unknown rejection: {top_reason}")
+
 
 class HttpAPI:
-    """HTTP endpoint handlers for control and gallery operations.
+    """HTTP endpoint handlers for the UUID-keyed face gallery.
 
     Parameters
     ----------
     who : WhoTracker
-        Presence tracker; used to answer `/who` queries.
+        Presence tracker; used to answer ``/who`` queries.
     scrfd : TRTSCRFD
-        Detector reference; used for hot-applying NMS threshold (from `/config`).
-    gm : GalleryManager or None
-        Gallery manager for alignment/embedding. If None, recognition endpoints
-        will return `{ "error": "recognition disabled" }`.
+        Detector reference; used for ``/config`` hot-tunables and to align
+        ``/gallery/add_raw`` uploads.
+    gallery : UUIDGallery or None
+        UUID-keyed gallery. ``None`` disables all recognition endpoints.
+    auto_enroller : AutoEnroller or None
+        Optional auto-enrollment subsystem. If provided, ``/selfie`` will
+        consult its per-track buffer to find an already-committed UUID
+        for the current face before creating a new one.
     gallery_dir : str
-        Filesystem root of the gallery.
+        Filesystem root of the gallery (also the path passed to
+        ``UUIDGallery``).
     gal_state : Any
-        Mutable object holding in-memory gallery features and labels.
-        Expected attributes: `gal_feats: np.ndarray|None`, `gal_labels: list[str]`.
+        Mutable object holding in-memory centroids consumed by recognition.
+        Expected attributes: ``gal_feats: np.ndarray|None``,
+        ``gal_labels: list[str]``, ``gal_uuids: list[str]``.
     gal_lock : threading.Lock
-        Lock guarding `gal_state` updates.
-    cfg : dict[str, object]
-        Live runtime configuration (blur mode, thresholds, etc.).
+        Lock guarding ``gal_state`` reads/writes.
+    cfg : dict
+        Live runtime configuration (thresholds, modes).
     cfg_lock : threading.Lock
-        Lock guarding `cfg` reads/writes.
+        Lock guarding ``cfg``.
     frame_state : Any
-        Holder for the last clean frame and detections/landmarks captured
-        by the main loop. Expected attributes: `frame_bgr`, `dets`, `kpss`.
+        Last clean frame + detections, captured by the main loop.
+        Expected attributes: ``frame_bgr``, ``dets``, ``kpss``,
+        ``current_faces``, ``current_unknowns``, ``last_ts``.
     frame_lock : threading.Lock
-        Lock guarding `frame_state` reads/writes.
+        Lock guarding ``frame_state``.
     run_job_sync : Callable[[Callable[[], Any]], Any]
         Enqueue-and-wait helper that runs the given function on the main
-        thread (via the job queue) and returns its result.
+        thread and returns its result.
     logger : logging.Logger, optional
-        Logger to use; if omitted, a default `http_api` logger is created.
+        Logger to use; defaults to ``logging.getLogger("http_api")``.
+    face_tracker : FaceTracker, optional
+        Face tracker reference. Used to look up the currently-tracked face
+        UUID at the time of ``/selfie`` so we can drain the matching
+        auto-enroll buffer.
     """
 
     def __init__(
@@ -76,7 +127,8 @@ class HttpAPI:
         *,
         who,
         scrfd,
-        gm,
+        gallery,
+        auto_enroller,
         gallery_dir: str,
         gal_state,
         gal_lock: threading.Lock,
@@ -88,10 +140,10 @@ class HttpAPI:
         logger: Optional[logging.Logger] = None,
         face_tracker=None,
     ):
-        """Initialize the HTTP API wrapper."""
         self.who = who
         self.scrfd = scrfd
-        self.gm = gm
+        self.gallery = gallery
+        self.auto_enroller = auto_enroller
         self.gallery_dir = gallery_dir
         self.gal_state = gal_state
         self.gal_lock = gal_lock
@@ -104,329 +156,438 @@ class HttpAPI:
         self.server = None
         self.face_tracker = face_tracker
 
-        # Selfie pipeline state
-        self.selfie_lock = threading.Lock()  # serialize concurrent /selfie
-        self.enrollment_lock = threading.Lock()  # protect last_enrollment dict
-        self.audit_lock = threading.Lock()  # serialize corrections.log writes
+        # Serialize /selfie (gallery + last_enrollment can't tolerate
+        # concurrent writes from two callers)
+        self.selfie_lock = threading.Lock()
+        # Protect last_enrollment dict
+        self.enrollment_lock = threading.Lock()
+        # Serialize corrections.log writes
+        self.audit_lock = threading.Lock()
+        # Tracks the most recent enrollment so /gallery/forget_last and
+        # /gallery/restore can act on "the one we just made". UUID-keyed.
+        # Shape: {"uuid", "name", "monotonic_ts", "wall_ts", "merged",
+        #         "source", "sample_count"}
         self.last_enrollment: Optional[Dict[str, Any]] = None
+        # Tracks the most recently soft-deleted UUID so /gallery/restore
+        # can default to it when no UUID is provided. Cleared when the
+        # UUID is restored or when trash is emptied.
+        self.last_soft_deleted: Optional[str] = None
 
     def stop(self) -> None:
-        """Stop an attached HTTP server if present."""
+        """Stop the embedded HTTP server. Idempotent; errors during shutdown
+        are swallowed (typical e.g. when server is already stopped).
+        """
         try:
             if self.server:
                 self.server.stop()
         except Exception:
             pass
 
+    # ==================================================================
+    # Dispatch
+    # ==================================================================
+
     def _handle(self, payload: Dict[str, Any], path: str) -> Dict[str, Any]:
         """Dispatch a POST request to the appropriate handler.
 
-        Parameters
-        ----------
-        payload : dict
-            JSON body of the request (may be empty for some endpoints).
-        path : str
-            Request path, e.g. `/who`, `/config`, `/gallery/refresh`.
-
-        Returns
-        -------
-        dict
-            JSON-serializable response. On errors, returns `{ "error": <msg> }`.
-
-        Endpoints
-        ---------
-        - `/ping`                → `{ "ok": true }`
-        - `/ts`                  → `{ "ts": <unix_seconds> }`
-        - `/who`                 → presence snapshot for `recent_sec`
-        - `/config`              → get/set live config
-        - `/gallery/refresh`     → incremental align+embed and update centroids
-        - `/gallery/add_aligned` → add a 112×112 aligned crop for an identity
-        - `/gallery/add_raw`     → copy a raw image and refresh gallery
-        - `/selfie`              → enroll from the last clean frame (aligned only)
+        On error returns ``{"error": <message>}``; never raises.
         """
         try:
+            # Liveness / utility
             if path == "/ping":
                 return {"ok": True}
-
             if path == "/ts":
                 return {"ts": time.time()}
 
+            # Presence
             if path == "/who":
-                sec = (
-                    float(payload.get("recent_sec", self.who.lookback_sec))
-                    if payload
-                    else self.who.lookback_sec
-                )
-                result = self.who.snapshot(sec)
+                return self._handle_who(payload)
 
-                # Read frame + faces + unknowns under one lock (consistent snapshot)
-                with self.frame_lock:
-                    frm = (
-                        self.frame_state.frame_bgr.copy()
-                        if self.frame_state.frame_bgr is not None
-                        else None
-                    )
-                    faces = self.frame_state.current_faces
-                    unknowns = self.frame_state.current_unknowns
-
-                if self.face_tracker is not None:
-                    result["faces"] = faces
-                    if unknowns:
-                        result["unknown_captures"] = unknowns
-
-                if frm is not None:
-                    _, buf = cv2.imencode(".jpg", frm, [cv2.IMWRITE_JPEG_QUALITY, 80])
-                    result["frame_b64"] = base64.b64encode(buf.tobytes()).decode(
-                        "ascii"
-                    )
-                    result["frame_hw"] = list(frm.shape[:2])
-                    result["frame_ts"] = time.time()
-                else:
-                    result["frame_b64"] = None
-                    result["frame_hw"] = None
-                    result["frame_ts"] = None
-
-                return result
-
+            # Config
             if path == "/config":
                 return self._handle_config(payload)
 
+            # Gallery: reading
+            if path in ("/gallery/identities", "/gallery/list_identities"):
+                return self._handle_gallery_identities()
+            if path == "/gallery/auto_enroll_status":
+                return self._handle_auto_enroll_status()
+
+            # Gallery: writing
             if path == "/gallery/refresh":
                 return self._handle_gallery_refresh()
-
             if path == "/gallery/add_aligned":
                 return self._handle_gallery_add_aligned(payload)
-
             if path == "/gallery/add_raw":
                 return self._handle_gallery_add_raw(payload)
-
             if path == "/selfie":
                 return self._handle_selfie(payload)
 
-            if path == "/gallery/delete":
-                return self._handle_gallery_delete(payload)
-
-            if path in ("/gallery/identities", "/gallery/list_identities"):
-                return self._handle_gallery_identities()
-
-            if path == "/gallery/move_samples":
-                return self._handle_gallery_move_samples(payload)
-
+            # Gallery: identity lifecycle
+            if path == "/set_name":
+                return self._handle_set_name(payload)
             if path == "/gallery/forget_last":
                 return self._handle_gallery_forget_last(payload)
+            if path == "/gallery/restore":
+                return self._handle_gallery_restore(payload)
+            if path == "/gallery/delete":
+                return self._handle_gallery_delete(payload)
+            if path == "/gallery/empty_trash":
+                return self._handle_gallery_empty_trash()
+            if path == "/gallery/merge":
+                return self._handle_gallery_merge(payload)
+            if path == "/gallery/find_similar":
+                return self._handle_gallery_find_similar(payload)
 
             return {"error": f"unknown path {path}"}
         except Exception as e:
-            self.log.exception("HTTP error")
+            self.log.exception("HTTP error on %s", path)
             return {"error": str(e)}
+
+    # ==================================================================
+    # /who
+    # ==================================================================
+
+    def _handle_who(self, payload: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Return presence snapshot plus the current frame as base64."""
+        sec = (
+            float(payload.get("recent_sec", self.who.lookback_sec))
+            if payload
+            else self.who.lookback_sec
+        )
+        result = self.who.snapshot(sec)
+
+        # Read frame + faces + unknowns under one lock (consistent snapshot)
+        with self.frame_lock:
+            frm = (
+                self.frame_state.frame_bgr.copy()
+                if self.frame_state.frame_bgr is not None
+                else None
+            )
+            faces = self.frame_state.current_faces
+            unknowns = self.frame_state.current_unknowns
+
+        if self.face_tracker is not None:
+            result["faces"] = faces
+            if unknowns:
+                result["unknown_captures"] = unknowns
+
+        if frm is not None:
+            _, buf = cv2.imencode(".jpg", frm, [cv2.IMWRITE_JPEG_QUALITY, 80])
+            result["frame_b64"] = base64.b64encode(buf.tobytes()).decode("ascii")
+            result["frame_hw"] = list(frm.shape[:2])
+            result["frame_ts"] = time.time()
+        else:
+            result["frame_b64"] = None
+            result["frame_hw"] = None
+            result["frame_ts"] = None
+
+        return result
+
+    # ==================================================================
+    # /config
+    # ==================================================================
 
     def _handle_config(self, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Get or set live runtime configuration.
 
-        Parameters
-        ----------
-        payload : dict
-            Either `{"get": true}` to fetch config or `{"set": {...}}` to update
-            a subset of known keys.
+        Payload forms:
+          {"get": true}                  → return current cfg
+          {"set": {"key": value, ...}}   → update keys (only existing ones)
+        """
+        payload = payload or {}
+        if payload.get("get"):
+            with self.cfg_lock:
+                return {"ok": True, "cfg": dict(self.cfg)}
+        if "set" in payload and isinstance(payload["set"], dict):
+            updates = payload["set"]
+            applied: Dict[str, Any] = {}
+            with self.cfg_lock:
+                for k, v in updates.items():
+                    if k in self.cfg:
+                        # Preserve type — coerce v through type(old)
+                        try:
+                            self.cfg[k] = type(self.cfg[k])(v)
+                            applied[k] = self.cfg[k]
+                        except (TypeError, ValueError) as e:
+                            return {"error": "bad_value", "key": k, "detail": str(e)}
+            # Some keys need to push into engines/trackers right away
+            if "nms" in applied and self.scrfd is not None:
+                self.scrfd.nms_thresh = float(applied["nms"])
+            return {"ok": True, "applied": applied}
+        return {"error": "missing get|set"}
+
+    # ==================================================================
+    # /gallery/identities
+    # ==================================================================
+
+    def _handle_gallery_identities(self) -> Dict[str, Any]:
+        """List all identities in the gallery.
 
         Returns
         -------
-        dict
-            - For get: `{ "config": { ... } }`
-            - For set: `{ "ok": true, "changed": { ... } }`
-            - On misuse: `{ "error": "...", "config_keys": [...] }`
-
-        Notes
-        -----
-        Updates are applied under `cfg_lock`. If the `nms` key is changed and a
-        detector is available, `scrfd.nms_thresh` is updated immediately.
-        """
-        if payload and payload.get("get"):
-            with self.cfg_lock:
-                return {"config": self.cfg}
-
-        if payload and "set" in payload and isinstance(payload["set"], dict):
-            changed = {}
-            with self.cfg_lock:
-                for k, v in payload["set"].items():
-                    if k in self.cfg:
-                        self.cfg[k] = v
-                        changed[k] = v
-                # hot-apply SCRFD NMS if changed
-                try:
-                    self.scrfd.nms_thresh = float(self.cfg["nms"])  # type: ignore
-                except Exception:
-                    pass
-            return {"ok": True, "changed": changed}
-
-        return {
-            "error": "use {'get':true} or {'set':{...}}",
-            "config_keys": list(self.cfg.keys()),
+        {
+            "ok": true,
+            "total": <int>,
+            "identities": [
+                {"uuid": "...", "name": "...", "sample_count": N,
+                 "created_at": "...", "updated_at": "...", "source": "..."},
+                ...
+            ]
         }
+        """
+        if self.gallery is None:
+            return {"ok": True, "total": 0, "identities": []}
+        items = self.gallery.list_identities()
+        return {"ok": True, "total": len(items), "identities": items}
+
+    # ==================================================================
+    # /gallery/auto_enroll_status
+    # ==================================================================
+
+    def _handle_auto_enroll_status(self) -> Dict[str, Any]:
+        """Diagnostic snapshot of the auto-enroll subsystem."""
+        if self.auto_enroller is None:
+            return {"ok": True, "enabled": False}
+        return {"ok": True, "enabled": True, **self.auto_enroller.snapshot()}
+
+    # ==================================================================
+    # /gallery/refresh
+    # ==================================================================
 
     def _handle_gallery_refresh(self) -> Dict[str, Any]:
-        """Incrementally process new images and update in-memory centroids.
+        """Re-scan the gallery directory and refresh in-memory centroids.
 
-        Returns
-        -------
-        dict
-            `{ "ok": true, "identities": <int>, "aligned_added": <int>,
-               "vectors_added": <int>, "took_sec": <float> }`
-            or `{ "error": "recognition disabled" }` if `gm` is not set.
+        Used after manual file-level edits (e.g. dragging in extra
+        ``aligned/*.jpg`` files). Fast: just disk I/O + in-memory load,
+        no GPU.
         """
-        if not self.gm:
-            return {"error": "recognition disabled"}
-        t0 = time.time()
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
 
         def _do():
-            a_add, v_add = self.gm.refresh(process_raw=True)
-            feats, labels = self.gm.get_identity_means()
+            n_loaded = self.gallery.reload()
+            feats, labels, uuids = self.gallery.get_centroids()
             with self.gal_lock:
-                self.gal_state.gal_feats, self.gal_state.gal_labels = feats, labels
-            return a_add, v_add, len(labels)
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return n_loaded, len(uuids)
 
-        a_add, v_add, n_id = self.run_job_sync(_do)
+        t0 = time.monotonic()
+        n_loaded, n_active = self.run_job_sync(_do)
         return {
             "ok": True,
-            "identities": int(n_id),
-            "aligned_added": int(a_add),
-            "vectors_added": int(v_add),
-            "took_sec": round(time.time() - t0, 3),
+            "identities_loaded": int(n_loaded),
+            "identities_with_samples": int(n_active),
+            "took_sec": round(time.monotonic() - t0, 3),
         }
 
-    # -------------------- /gallery/add_aligned --------------------- #
+    # ==================================================================
+    # /gallery/add_aligned
+    # ==================================================================
+
     def _handle_gallery_add_aligned(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Add a 112×112 aligned face to the gallery and update centroids.
-
-        Parameters
-        ----------
-        payload : dict
-            Must include `"id"` (identity label). Provide either
-            `"image_path"` or `"image_b64"`.
-
-        Returns
-        -------
-        dict
-            On success: `{ "ok": true, "added": <rel_path>, "identities": <int> }`.
-            On failure: `{ "error": "...") }` or `{ "ok": false, "error": "..." }`.
-        """
-        if not self.gm:
-            return {"error": "recognition disabled"}
-        if not payload or "id" not in payload:
-            return {"error": "missing 'id'"}
-        person = str(payload["id"])
-        image_path = payload.get("image_path")
-        image_b64 = payload.get("image_b64")
-        if not image_path and not image_b64:
-            return {"error": "provide 'image_path' or 'image_b64'"}
-
-        img112 = self._load_112(image_path, image_b64)
-        if img112 is None:
-            return {"ok": False, "error": "failed to load image"}
-        fname_hint = os.path.basename(image_path) if image_path else None
-
-        def _do_add():
-            rel = self.gm.add_aligned_snapshot(person, img112, fname_hint=fname_hint)
-            feats, labels = self.gm.get_identity_means()
-            with self.gal_lock:
-                self.gal_state.gal_feats, self.gal_state.gal_labels = feats, labels
-            return rel, len(labels)
-
-        rel, n_id = self.run_job_sync(_do_add)
-        return {"ok": True, "added": rel, "identities": int(n_id)}
-
-    def _handle_gallery_add_raw(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Copy a raw image into gallery/<id>/raw and run full refresh (align+embed).
-
-        Upload pathway -> RAW only. Alignment happens once during refresh.
-        Response: { ok, saved, identities }.
-
-        Parameters
-        ----------
-        payload : dict
-            Must include `"id"` (identity label) and `"image_path"` (absolute or
-            relative path to an existing image).
-
-        Returns
-        -------
-        dict
-            `{ "ok": true, "saved": <abs_path>, "identities": <int> }`
-            or an error object.
-
-        Notes
-        -----
-        After copying, this calls `gm.refresh(process_raw=True)` via
-        `run_job_sync` to align new raw images and append embeddings.
-        """
-        if not self.gm:
-            return {"error": "recognition disabled"}
-        if not payload or "id" not in payload or "image_path" not in payload:
-            return {"error": "need 'id' and 'image_path'"}
-
-        person = str(payload["id"])
-        src = str(payload["image_path"])
-        if not os.path.exists(src):
-            return {"error": f"image_path not found: {src}"}
-
-        raw_dir = os.path.join(self.gallery_dir, person, "raw")
-        os.makedirs(raw_dir, exist_ok=True)
-        dst = os.path.join(raw_dir, os.path.basename(src))
-        shutil.copy2(src, dst)
-
-        def _do_refresh():
-            _a_added, _v_added = self.gm.refresh(process_raw=True)
-            feats, labels = self.gm.get_identity_means()
-            with self.gal_lock:
-                self.gal_state.gal_feats, self.gal_state.gal_labels = feats, labels
-            return len(labels)
-
-        n_id = self.run_job_sync(_do_refresh)
-        return {"ok": True, "saved": dst, "identities": int(n_id)}
-
-    def _handle_selfie(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Multi-frame selfie enrollment with score-based target selection,
-        dedup, identity-consistency check, and adaptive sample count.
+        """Add a pre-aligned 112×112 crop to the gallery.
 
         Payload
         -------
-        id    : str  (required) — requested identity name (lowercase, alnum/_/-)
+        uuid  : str (optional) — target UUID. If omitted, looks up by name;
+                if no UUID matches the name, creates a new UUID.
+        name  : str (required if no uuid) — display name for new UUID.
+        image_path : str (one of image_path / image_b64 required)
+        image_b64  : str
+
+        Returns
+        -------
+        {"ok": True, "uuid": "...", "name": "...", "sample_count": N,
+         "took_sec": ...}
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+        payload = payload or {}
+        uuid = str(payload.get("uuid", "")).strip()
+        name = str(payload.get("name", "")).strip().lower()
+
+        img = self._load_112(payload.get("image_path"), payload.get("image_b64"))
+        if img is None:
+            return {"error": "no_image"}
+
+        if not uuid and not name:
+            return {"error": "missing_uuid_or_name"}
+
+        if name:
+            ok, reason = sl.validate_identity_name(name)
+            if not ok:
+                return {"error": "bad_name", "detail": reason}
+
+        def _do():
+            target_uuid = uuid
+            # Resolve name → UUID if no UUID given. Pick the first match.
+            if not target_uuid and name:
+                matches = self.gallery.find_by_name(name)
+                if matches:
+                    target_uuid = matches[0]
+                else:
+                    target_uuid = self.gallery.create(name=name, source="add_aligned")
+            elif not self.gallery.get_record(target_uuid):
+                return None, f"uuid not found: {target_uuid}"
+
+            self.gallery.add_sample(target_uuid, img)
+            rec = self.gallery.get_record(target_uuid)
+
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return rec, None
+
+        t0 = time.monotonic()
+        rec, err = self.run_job_sync(_do)
+        if err:
+            return {"error": err}
+        return {
+            "ok": True,
+            "uuid": rec.uuid,
+            "name": rec.name,
+            "sample_count": rec.sample_count,
+            "took_sec": round(time.monotonic() - t0, 3),
+        }
+
+    # ==================================================================
+    # /gallery/add_raw
+    # ==================================================================
+
+    def _handle_gallery_add_raw(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Add a raw (any-size) image: detect → align → embed → add."""
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+        if self.scrfd is None:
+            return {"error": "no_detector"}
+
+        payload = payload or {}
+        uuid = str(payload.get("uuid", "")).strip()
+        name = str(payload.get("name", "")).strip().lower()
+
+        if not uuid and not name:
+            return {"error": "missing_uuid_or_name"}
+        if name:
+            ok, reason = sl.validate_identity_name(name)
+            if not ok:
+                return {"error": "bad_name", "detail": reason}
+
+        img_path = payload.get("image_path")
+        img_b64 = payload.get("image_b64")
+        raw = None
+        if img_path:
+            raw = cv2.imread(img_path)
+        elif img_b64:
+            try:
+                buf = base64.b64decode(img_b64)
+                arr = np.frombuffer(buf, dtype=np.uint8)
+                raw = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+            except Exception:
+                raw = None
+        if raw is None:
+            return {"error": "no_image"}
+
+        det_conf_snap = float(self.cfg.get("conf", 0.5))
+
+        def _do():
+            dets, kpss = self.scrfd.detect(raw, conf=det_conf_snap)
+            if dets is None or dets.shape[0] == 0:
+                return None, "no_face"
+            # Pick largest face
+            areas = (dets[:, 2] - dets[:, 0]) * (dets[:, 3] - dets[:, 1])
+            i = int(np.argmax(areas))
+            if kpss is not None and i < len(kpss):
+                crop = warp_face_by_5p(raw, kpss[i], 112)
+            else:
+                x1, y1, x2, y2 = dets[i, :4].astype(int)
+                face = raw[max(0, y1) : max(0, y2), max(0, x1) : max(0, x2)]
+                if face.size == 0:
+                    return None, "no_face_crop"
+                crop = cv2.resize(face, (112, 112))
+
+            target_uuid = uuid
+            if not target_uuid and name:
+                matches = self.gallery.find_by_name(name)
+                target_uuid = (
+                    matches[0]
+                    if matches
+                    else self.gallery.create(
+                        name=name,
+                        source="add_raw",
+                    )
+                )
+            elif not self.gallery.get_record(target_uuid):
+                return None, f"uuid not found: {target_uuid}"
+
+            self.gallery.add_sample(target_uuid, crop)
+            rec = self.gallery.get_record(target_uuid)
+
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return rec, None
+
+        t0 = time.monotonic()
+        rec, err = self.run_job_sync(_do)
+        if err:
+            return {"error": err}
+        return {
+            "ok": True,
+            "uuid": rec.uuid,
+            "name": rec.name,
+            "sample_count": rec.sample_count,
+            "took_sec": round(time.monotonic() - t0, 3),
+        }
+
+    # ==================================================================
+    # /selfie — multi-frame enrollment from the live camera
+    # ==================================================================
+
+    def _handle_selfie(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Collect 1-N frames from the live camera and enroll the addressee.
+
+        Payload
+        -------
+        name  : str (required) — display name to assign
         force : bool (optional) — bypass cross-name reject (twins/lookalikes)
 
         Returns (success)
         -----------------
-        { ok:True, id, merged, forced, samples_saved, match_sim, identities }
+        {ok:True, uuid, name, merged, forced, samples_saved, match_sim,
+         match_name, identities}
 
         Errors
         ------
-        bad_id | recognition_disabled | busy | no_valid_frames |
+        bad_name | recognition_disabled | busy | no_valid_frames |
         insufficient_samples | ambiguous_subjects | face_belongs_to
         """
-        if not self.gm:
+        if self.gallery is None:
             return {"error": "recognition_disabled"}
 
         payload = payload or {}
-        requested = str(payload.get("id", "")).strip().lower()
+        # Accept both new "name" and legacy "id" keys for compatibility.
+        requested = str(payload.get("name") or payload.get("id", "")).strip().lower()
         ok, reason = sl.validate_identity_name(requested)
         if not ok:
-            return {"error": "bad_id", "detail": reason}
-
+            return {"error": "bad_name", "detail": reason}
         force = bool(payload.get("force", False))
 
-        # Serialize concurrent /selfie calls — gallery + last_enrollment can't
-        # tolerate interleaved enrollment from two callers at once.
         if not self.selfie_lock.acquire(blocking=False):
             return {"error": "busy"}
-
         try:
             return self._do_selfie(requested, force)
         finally:
             self.selfie_lock.release()
 
     def _do_selfie(self, requested: str, force: bool) -> Dict[str, Any]:
-        """Core selfie collection loop. Caller holds self.selfie_lock."""
-        # Snapshot cfg once so thresholds stay consistent for this request
+        """Core selfie loop. Caller holds self.selfie_lock."""
         with self.cfg_lock:
             cfg_snap = dict(self.cfg)
 
@@ -443,20 +604,34 @@ class HttpAPI:
         crops: List[np.ndarray] = []
         embs: List[np.ndarray] = []
         running_mean: Optional[np.ndarray] = None
-        target_id: Optional[str] = None
-        merged_flag = False
-        match_label: Optional[str] = None
-        match_sim_seen = 0.0
-        ambiguity_streak = 0
-        last_seen_token = -1  # frame-change detection (see below)
 
-        # ----- Phase 2: Collection loop -----
+        # Rejection-reason counter for debugging "no_valid_frames" failures.
+        # Counts each frame that was skipped and why. Keys mirror quality_check
+        # reasons plus the higher-level pipeline skips.
+        reject_reasons: Dict[str, int] = {}
+        frames_seen = 0  # total frames inspected (not "skipped because stale")
+
+        def _bump(reason: str) -> None:
+            reject_reasons[reason] = reject_reasons.get(reason, 0) + 1
+
+        target_uuid: Optional[str] = None
+        target_name: str = requested
+        merged_flag = False
+        match_name: Optional[str] = None
+        match_uuid: Optional[str] = None
+        match_sim_seen = 0.0
+        # Explicit "have we resolved which identity to enroll into yet" flag.
+        # Don't conflate with target_uuid==None — for the new-UUID case
+        # target_uuid is legitimately None after resolution (we'll mint a
+        # UUID at commit time).
+        resolved = False
+        last_seen_token = -1
+
         while len(crops) < max_samples and time.monotonic() < deadline:
-            # (A) Snapshot frame_state under lock, release fast
+            # Snapshot clean frame under lock
             with self.frame_lock:
                 if self.frame_state.frame_bgr is None:
-                    frm = None
-                    dets = kpss = None
+                    frm, dets, kpss = None, None, None
                     ts = 0.0
                 else:
                     frm = self.frame_state.frame_bgr.copy()
@@ -472,582 +647,778 @@ class HttpAPI:
                     )
                     ts = float(getattr(self.frame_state, "last_ts", 0.0))
 
-            # Prefer explicit last_ts if run.py is up-to-date. If it's 0.0
-            # (older run.py without the field), fall back to id(frm) — the
-            # array's memory address changes per .copy(), so consecutive
-            # snapshots produce distinct tokens.
             frame_token = ts if ts > 0 else (id(frm) if frm is not None else 0)
-
-            if frm is None or frame_token == last_seen_token:
-                time.sleep(0.02)
+            if frame_token == last_seen_token:
+                time.sleep(0.02)  # wait for fresh frame
                 continue
             last_seen_token = frame_token
+            frames_seen += 1
 
-            # (B) No detections this frame
-            if dets is None or len(dets) == 0:
+            if frm is None or dets is None or dets.shape[0] == 0:
+                _bump("no_face_detected")
+                time.sleep(tap_interval)
                 continue
 
-            # (C) Score every face: (bbox_area / frame_area) * frontality
-            h, w = frm.shape[:2]
-            frame_area = float(h * w)
-            scores = [
-                sl.score_face(
-                    dets[i],
-                    kpss[i] if kpss is not None and i < len(kpss) else None,
-                    frame_area,
-                )
-                for i in range(len(dets))
-            ]
-
-            # (D) Ambiguity — fail fast on 2 consecutive ambiguous frames
-            is_amb, top_ratio = sl.check_ambiguity(scores, ambig_ratio, score_floor)
-            if is_amb:
-                ambiguity_streak += 1
-                if ambiguity_streak >= 2:
-                    self.log.info(
-                        "selfie ambiguous: ratio=%.3f n_engaged=%d",
-                        top_ratio,
-                        sum(1 for s in scores if s >= score_floor),
-                    )
-                    return {
-                        "error": "ambiguous_subjects",
-                        "top_ratio": round(top_ratio, 3),
-                        "n_engaged": sum(1 for s in scores if s >= score_floor),
-                    }
-                continue
-            ambiguity_streak = 0  # reset on any clean frame
-
-            # (E) Pick target & engagement floor
-            target_idx = int(np.argmax(scores))
-            if scores[target_idx] < score_floor:
+            # Score each detected face — pick the most engaged
+            H, W = frm.shape[:2]
+            scores: List[float] = []
+            for d_idx in range(dets.shape[0]):
+                k = kpss[d_idx] if kpss is not None and d_idx < len(kpss) else None
+                scores.append(sl.score_face(dets[d_idx], k, float(H * W)))
+            top_idx = int(np.argmax(scores))
+            top_score = scores[top_idx]
+            if top_score < score_floor:
+                _bump("not_engaged")
                 continue
 
-            # (F) Need landmarks for alignment
-            if kpss is None or target_idx >= len(kpss):
-                continue
-            target_kps = kpss[target_idx]
-
-            # (G) Build aligned 112×112 crop + quality gate
-            crop = warp_face_by_5p(frm, target_kps, 112)
-            ok_q, q_reason = sl.quality_check(
-                crop, dets[target_idx], target_kps, cfg_snap
-            )
-            if not ok_q:
-                self.log.debug("selfie frame rejected: %s", q_reason)
+            # Ambiguity: skip frame if two faces are similarly engaged
+            ambiguous, _ = sl.check_ambiguity(scores, ambig_ratio, score_floor)
+            if ambiguous:
+                _bump("ambiguous_faces")
                 continue
 
-            # (H) Embed on main thread (GPU)
-            v = self.run_job_sync(lambda c=crop: self.gm.embed_aligned(c))
+            det = dets[top_idx]
+            kps = kpss[top_idx] if kpss is not None and top_idx < len(kpss) else None
 
-            # (I) First valid frame: dedup. Subsequent: consistency + novelty.
-            if target_id is None:
+            # Align
+            if kps is not None:
+                crop = warp_face_by_5p(frm, kps, 112)
+            else:
+                x1, y1, x2, y2 = det[:4].astype(int)
+                face = frm[max(0, y1) : max(0, y2), max(0, x1) : max(0, x2)]
+                if face.size == 0:
+                    _bump("empty_bbox")
+                    continue
+                crop = cv2.resize(face, (112, 112))
+
+            # Per-frame quality
+            ok, reason = sl.quality_check(crop, det, kps, cfg_snap)
+            if not ok:
+                _bump(reason or "quality_fail")
+                continue
+
+            # Embed (on main thread — TRT)
+            v = self.run_job_sync(lambda c=crop: self.gallery.embed_aligned(c))
+
+            # First valid frame → resolve target. Subsequent → consistency + novelty.
+            if not resolved:
+                # Pull gallery snapshot
                 with self.gal_lock:
                     feats = self.gal_state.gal_feats
                     labels = list(self.gal_state.gal_labels)
+                    uuids = list(getattr(self.gal_state, "gal_uuids", []))
 
                 decision = sl.resolve_target_id(
                     v,
                     requested,
                     feats,
                     labels,
+                    uuids,
                     cfg_snap,
                     force=force,
                 )
 
                 if decision.reject:
-                    self.log.info(
-                        "selfie face_belongs_to label=%s sim=%.3f",
-                        decision.match_label,
-                        decision.match_sim,
-                    )
                     return {
                         "error": "face_belongs_to",
-                        "name": decision.match_label,
+                        "name": decision.match_name,
+                        "uuid": decision.match_uuid,
                         "sim": round(decision.match_sim, 3),
                     }
 
-                target_id = decision.id
+                target_uuid = decision.uuid  # None = create new UUID at commit time
+                target_name = decision.name
                 merged_flag = decision.merged
-                match_label = decision.match_label
+                match_name = decision.match_name
+                match_uuid = decision.match_uuid
                 match_sim_seen = decision.match_sim
+                resolved = True
             else:
+                # Consistency + novelty against running_mean. running_mean
+                # is guaranteed non-None here because we set it in the
+                # previous iteration before bumping `resolved`.
                 sim = sl.cosine_to_mean(running_mean, v)
                 if sim < consist_thr:
-                    # Different person showed up mid-window
-                    self.log.debug("selfie frame rejected: consistency=%.3f", sim)
-                    continue
+                    _bump("consistency_fail")
+                    continue  # different person mid-window
                 if sim > novelty_thr:
-                    # Near-duplicate of what we've already collected
-                    self.log.debug("selfie frame rejected: not novel (sim=%.3f)", sim)
-                    continue
+                    _bump("novelty_fail")
+                    continue  # near-duplicate frame
 
-            # (J) Accept the frame
             crops.append(crop)
             embs.append(v)
             running_mean = sl.update_running_mean(running_mean, v, len(embs))
             time.sleep(tap_interval)
 
-        # ----- Phase 3: Finalize -----
+        # Finalize
         n = len(crops)
         if n == 0:
-            return {"error": "no_valid_frames"}
+            logger.warning(
+                "selfie no_valid_frames: frames_seen=%d rejections=%s",
+                frames_seen,
+                dict(reject_reasons),
+            )
+            return {
+                "error": "no_valid_frames",
+                "frames_seen": frames_seen,
+                "rejections": dict(reject_reasons),
+                "hint": _selfie_hint(reject_reasons),
+            }
         if n < min_samples:
-            return {"error": "insufficient_samples", "got": n}
+            logger.warning(
+                "selfie insufficient_samples: got=%d need=%d rejections=%s",
+                n,
+                min_samples,
+                dict(reject_reasons),
+            )
+            return {
+                "error": "insufficient_samples",
+                "got": n,
+                "need": min_samples,
+                "rejections": dict(reject_reasons),
+                "hint": _selfie_hint(reject_reasons),
+            }
 
-        ts_str = time.strftime("%Y-%m-%dT%H-%M-%S")
+        # Commit: create UUID if needed, then batch-add to the gallery.
+        # After commit, proactively drop the auto-enroll buffer for the
+        # track this selfie corresponds to — face_tracker will eventually
+        # do the same on its next recognition pass (when it sees the new
+        # centroid and the track becomes "confident"), but draining now
+        # avoids a brief window where the buffer could re-commit.
+        def _do_commit():
+            uuid = target_uuid
+            if uuid is None:
+                uuid = self.gallery.create(name=target_name, source="selfie")
+            else:
+                # Merging into existing UUID. If we're claiming an anon
+                # (target_name was overridden by resolve_target_id to the
+                # requested name), also rename the UUID now. set_name is
+                # O(1) so this is cheap. For non-claim merges (e.g. selfie
+                # of an already-named identity), target_name == existing
+                # name, so set_name is a no-op (same string).
+                rec = self.gallery.get_record(uuid)
+                if rec is not None and rec.name != target_name:
+                    self.gallery.set_name(uuid, target_name)
 
-        # Single main-thread batch: save each crop with its pre-computed vec,
-        # then recompute stats ONCE, then snapshot centroids into gal_state.
-        def _do_save_batch():
-            saved = []
-            for k, (c, v) in enumerate(zip(crops, embs)):
-                rel = self.gm.add_aligned_no_stats(
-                    target_id,
-                    c,
-                    vec=v,
-                    fname_hint=f"{ts_str}_{k:02d}.jpg",
-                )
-                saved.append(rel)
-            self.gm.recompute_stats()
-            feats, labels = self.gm.get_identity_means()
+            saved = self.gallery.add_samples(uuid, crops, embeddings=embs)
+            n_saved = len(saved)
+
+            # Refresh in-memory centroids so face_tracker picks up the
+            # new identity on its next frame.
+            feats, labels, uuids = self.gallery.get_centroids()
             with self.gal_lock:
                 self.gal_state.gal_feats = feats
                 self.gal_state.gal_labels = labels
-            return saved, len(labels)
+                self.gal_state.gal_uuids = uuids
 
-        saved_files, n_id = self.run_job_sync(_do_save_batch)
+            # Drop the auto-enroll buffer for the currently-tracked face,
+            # if any. Best-effort: if there's no auto-enroller, no face
+            # tracker, or no current face, this is a no-op.
+            if self.auto_enroller is not None and self.face_tracker is not None:
+                track_id = self._currently_tracked_track_id()
+                if track_id is not None:
+                    self.auto_enroller.drop_track(track_id)
 
-        # Record for /gallery/move_samples and /gallery/forget_last
+            return uuid, n_saved, len(uuids)
+
+        t0 = time.monotonic()
+        final_uuid, n_saved, n_id = self.run_job_sync(_do_commit)
+
         with self.enrollment_lock:
             self.last_enrollment = {
-                "id": target_id,
-                "files": saved_files,
+                "uuid": final_uuid,
+                "name": target_name,
                 "monotonic_ts": time.monotonic(),
                 "wall_ts": time.time(),
                 "merged": merged_flag,
                 "forced": force,
+                "sample_count": n_saved,
             }
 
         if force:
             self._audit_log(
-                f"selfie forced id={target_id} samples={n} "
-                f"matched={match_label or '-'} sim={match_sim_seen:.3f}"
-            )
-        else:
-            self.log.info(
-                "selfie ok id=%s merged=%s samples=%d",
-                target_id,
-                merged_flag,
-                n,
+                f"selfie forced uuid={final_uuid} name={target_name} "
+                f"matched={match_name or '-'} sim={match_sim_seen:.3f}"
             )
 
         return {
             "ok": True,
-            "id": target_id,
+            "uuid": final_uuid,
+            "name": target_name,
             "merged": merged_flag,
             "forced": force,
-            "samples_saved": n,
+            "samples_saved": n_saved,
+            "match_name": match_name,
+            "match_uuid": match_uuid,
             "match_sim": round(match_sim_seen, 3),
-            "identities": int(n_id),
-        }
-
-    def _handle_gallery_delete(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Delete one or more identities and rebuild the embed store.
-
-        Accepts:
-        {"id": "alice"}
-        {"ids": ["alice", "bob"]}
-        {"id": ["alice", "bob"]}
-
-        Returns (example):
-        {
-            "ok": true,
-            "deleted": ["alice"],
-            "failed": {"bob": "not found"},
-            "removed_gallery": true,
-            "identities": 0,
-            "aligned_used": 3,
-            "vectors_rebuilt": 3,
-            "took_sec": 0.112
-        }
-        """
-        if not self.gm:
-            return {"error": "recognition disabled"}
-        if not payload:
-            return {"error": "missing 'id' or 'ids'"}
-
-        # normalize to list[str]
-        ids = []
-        if "ids" in payload and isinstance(payload["ids"], list):
-            ids = [str(x) for x in payload["ids"]]
-        elif "id" in payload:
-            if isinstance(payload["id"], list):
-                ids = [str(x) for x in payload["id"]]
-            else:
-                ids = [str(payload["id"])]
-        else:
-            return {"error": "missing 'id' or 'ids'"}
-
-        if not ids:
-            return {"error": "no identities provided"}
-
-        t0 = time.time()
-
-        def _do():
-            deleted: List[str] = []
-            failed: Dict[str, str] = {}
-            removed_any = False
-            total_aligned = 0
-            total_vectors = 0
-
-            for person in ids:
-                try:
-                    removed_gallery, aligned_used, vectors_rebuilt, _n_id = (
-                        self.gm.delete_identity(person)
-                    )
-                    if removed_gallery or aligned_used or vectors_rebuilt:
-                        deleted.append(person)
-                        removed_any = removed_any or bool(removed_gallery)
-                        total_aligned += int(aligned_used)
-                        total_vectors += int(vectors_rebuilt)
-                    else:
-                        # gm.delete_identity returned 0 changes: treat as not found
-                        failed[person] = "not found or no changes"
-                except Exception as e:
-                    failed[person] = str(e)
-
-            # always refresh means after batch
-            feats, labels = self.gm.get_identity_means()
-            with self.gal_lock:
-                self.gal_state.gal_feats, self.gal_state.gal_labels = feats, labels
-
-            return (
-                deleted,
-                failed,
-                removed_any,
-                total_aligned,
-                total_vectors,
-                len(labels),
-            )
-
-        deleted, failed, removed_any, total_aligned, total_vectors, n_id = (
-            self.run_job_sync(_do)
-        )
-        return {
-            "ok": len(failed) == 0,  # true only if all succeeded
-            "deleted": deleted if len(deleted) != 1 else deleted[0],
-            "failed": failed or None,
-            "removed_gallery": bool(removed_any),
-            "identities": int(n_id),
-            "aligned_used": int(total_aligned),
-            "vectors_rebuilt": int(total_vectors),
-            "took_sec": round(time.time() - t0, 3),
-        }
-
-    def _handle_gallery_identities(self) -> Dict[str, Any]:
-        """
-        List identity folders under the gallery with lightweight counts.
-
-        Returns
-        -------
-        dict
-            {
-            "ok": true,
-            "total": <int>,                # number of identities
-            "identities": [
-                {"id": "Alice", "aligned": 12, "raw": 3},
-                {"id": "Bob",   "aligned":  5, "raw": 0}
-            ]
-            }
-        """
-
-        def _count_images(dir_path: str) -> int:
-            if not osp.isdir(dir_path):
-                return 0
-            exts = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
-            try:
-                return sum(
-                    1
-                    for fn in os.listdir(dir_path)
-                    if osp.splitext(fn)[1].lower() in exts
-                )
-            except Exception:
-                return 0
-
-        gallery_root = self.gallery_dir
-        if not gallery_root or not osp.isdir(gallery_root):
-            return {"ok": True, "total": 0, "identities": []}
-
-        identities = []
-        try:
-            # List first-level folders as identities
-            for name in sorted(os.listdir(gallery_root)):
-                p = osp.join(gallery_root, name)
-                if not osp.isdir(p):
-                    continue
-                aligned_dir = osp.join(p, "aligned")
-                raw_dir = osp.join(p, "raw")
-                identities.append(
-                    {
-                        "id": name,
-                        "aligned": _count_images(aligned_dir),
-                        "raw": _count_images(raw_dir),
-                    }
-                )
-        except Exception as e:
-            return {"ok": False, "error": str(e)}
-
-        return {"ok": True, "total": len(identities), "identities": identities}
-
-    # -------------------- /gallery/move_samples --------------------- #
-    def _handle_gallery_move_samples(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Move samples from one identity to another.
-
-        Use cases:
-        - Rename (typo correction): to_id doesn't exist → folder is renamed.
-        - Merge into existing: to_id exists → samples merged in, from_id empty
-          folder deleted.
-
-        Payload
-        -------
-        from_id : str (required)
-        to_id   : str (required)
-        files   : List[str] (optional) — relative paths under gallery_dir.
-                  If omitted, uses last_enrollment.files (60s TTL; id must match).
-        """
-        if not self.gm:
-            return {"error": "recognition_disabled"}
-
-        payload = payload or {}
-        from_id = str(payload.get("from_id", "")).strip().lower()
-        to_id = str(payload.get("to_id", "")).strip().lower()
-
-        for label, name in (("from_id", from_id), ("to_id", to_id)):
-            ok, reason = sl.validate_identity_name(name)
-            if not ok:
-                return {"error": "bad_id", "detail": f"{label}: {reason}"}
-
-        if from_id == to_id:
-            return {"error": "same_id"}
-
-        payload_files = payload.get("files")
-        if payload_files:
-            files_to_move = [str(f) for f in payload_files]
-        else:
-            with self.enrollment_lock:
-                le = self.last_enrollment
-                if le is None or le["id"] != from_id:
-                    return {
-                        "error": "no_recent_enrollment",
-                        "detail": "supply files=[...] or call within 60s of /selfie",
-                    }
-                if time.monotonic() - le["monotonic_ts"] > 60.0:
-                    return {"error": "stale_enrollment"}
-                files_to_move = list(le["files"])
-
-        # Path traversal guard: every file must resolve to inside gallery_dir
-        safe_files = self._filter_safe_paths(files_to_move)
-        if not safe_files:
-            return {"error": "no_safe_files"}
-
-        t0 = time.monotonic()
-        moved, from_removed, n_id = self.run_job_sync(
-            lambda: self._do_move_samples(from_id, to_id, safe_files)
-        )
-
-        # Clear last_enrollment if we just consumed it
-        with self.enrollment_lock:
-            if (
-                self.last_enrollment is not None
-                and self.last_enrollment["id"] == from_id
-            ):
-                self.last_enrollment = None
-
-        return {
-            "ok": True,
-            "from_id": from_id,
-            "to_id": to_id,
-            "moved": int(moved),
-            "from_removed": bool(from_removed),
             "identities": int(n_id),
             "took_sec": round(time.monotonic() - t0, 3),
         }
 
-    def _do_move_samples(
-        self, from_id: str, to_id: str, files: List[str]
-    ) -> "tuple[int, bool, int]":
-        """Main-thread worker. Returns (moved_count, from_removed, n_identities)."""
-        to_aligned = os.path.join(self.gallery_dir, to_id, "aligned")
-        os.makedirs(to_aligned, exist_ok=True)
+    def _currently_tracked_track_id(self) -> Optional[int]:
+        """Return the track_id of the largest currently-tracked face, if any.
 
-        moved = 0
-        for rel in files:
-            src = os.path.join(self.gallery_dir, rel)
-            if not os.path.isfile(src):
-                continue
-            fname = os.path.basename(rel)
-            dst = os.path.join(to_aligned, fname)
-            if os.path.exists(dst):
-                # Collision: append _moved<n> to disambiguate
-                base, ext = os.path.splitext(fname)
-                k = 1
-                while True:
-                    dst = os.path.join(to_aligned, f"{base}_moved{k}{ext}")
-                    if not os.path.exists(dst):
-                        break
-                    k += 1
-            shutil.move(src, dst)
-            moved += 1
-
-        from_removed = self._cleanup_empty_identity_dir(from_id)
-
-        # Rebuild from scratch — refresh() only adds, doesn't remove stale entries
-        self.gm.clear_and_rebuild()
-        feats, labels = self.gm.get_identity_means()
-        with self.gal_lock:
-            self.gal_state.gal_feats = feats
-            self.gal_state.gal_labels = labels
-
-        self._audit_log(
-            f"move {from_id}->{to_id} files={len(files)} moved={moved} "
-            f"from_removed={from_removed}"
-        )
-        return moved, from_removed, len(labels)
-
-    # -------------------- /gallery/forget_last --------------------- #
-    def _handle_gallery_forget_last(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        Used by /selfie to drop the auto-enroll buffer for the same track
+        after committing. ``current_faces`` is sorted by bbox area
+        descending, so faces[0] is the closest/most prominent face.
         """
-        Delete the samples saved by the most recent /selfie call.
-        Used when the wrong person was captured.
+        if self.face_tracker is None:
+            return None
+        with self.frame_lock:
+            faces = list(self.frame_state.current_faces)
+        if not faces:
+            return None
+        return faces[0].get("track_id")
 
-        Payload (optional)
-        ------------------
-        id : str — if provided, must match last_enrollment.id (safety check)
+    # ==================================================================
+    # /set_name
+    # ==================================================================
+
+    def _handle_set_name(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Update the display name of an identity. O(1), no GPU.
+
+        Two usage patterns:
+          1. ``{"uuid": "<hex32>", "name": "wendy"}`` — rename by UUID.
+          2. ``{"track_id": 5, "name": "wendy"}`` — name the person currently
+             on the screen as track #5. If that track is already mapped to
+             a confident UUID, we set_name on that UUID. Otherwise, if
+             auto-enroll has buffered samples for that track, we force-commit
+             to a brand-new UUID with the given name.
+
+        Name collisions are intentionally allowed
+        -----------------------------------------
+        Two different people can share a display name (e.g. "two Wendys at
+        OpenMind"). Each keeps its own UUID; recognition distinguishes them
+        by face, not by name. Both will render as "wendy" on screen — that's
+        a UX choice, not an identity confusion.
+
+        To merge two UUIDs into one (same person, multiple enrollments),
+        use ``/gallery/merge`` — that's an explicit operation that requires
+        confirmation, not a side-effect of renaming.
+
+        Payload
+        -------
+        uuid     : str (optional)
+        track_id : int (optional, alternative to uuid)
+        name     : str (required) — new display name
         """
-        if not self.gm:
+        if self.gallery is None:
             return {"error": "recognition_disabled"}
 
         payload = payload or {}
+        new_name = str(payload.get("name", "")).strip().lower()
+        ok, reason = sl.validate_identity_name(new_name)
+        if not ok:
+            return {"error": "bad_name", "detail": reason}
 
+        uuid = str(payload.get("uuid", "")).strip()
+        track_id_raw = payload.get("track_id")
+
+        # Resolve which UUID to update
+        target_uuid: Optional[str] = None
+        created_via_force = False
+
+        if uuid:
+            if self.gallery.get_record(uuid) is None:
+                return {"error": "uuid_not_found", "uuid": uuid}
+            target_uuid = uuid
+        elif track_id_raw is not None:
+            try:
+                track_id = int(track_id_raw)
+            except (TypeError, ValueError):
+                return {"error": "bad_track_id"}
+            # Look up track on the face_tracker side
+            target_uuid = self._uuid_for_track(track_id)
+            if target_uuid is None:
+                # No confident identification yet. If auto-enroller has a
+                # buffer for this track, force-commit it with the name.
+                if self.auto_enroller is None:
+                    return {
+                        "error": "track_not_identified",
+                        "detail": "no auto-enroller available",
+                    }
+                target_uuid = self.run_job_sync(
+                    lambda: self.auto_enroller.force_commit(track_id, name=new_name)
+                )
+                if not target_uuid:
+                    return {
+                        "error": "track_not_identified",
+                        "detail": "no buffered samples for track",
+                    }
+                created_via_force = True
+        else:
+            return {"error": "missing_uuid_or_track_id"}
+
+        def _do():
+            if not created_via_force:
+                # If we didn't just create+name via force_commit, do the rename
+                self.gallery.set_name(target_uuid, new_name)
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return self.gallery.get_record(target_uuid)
+
+        rec = self.run_job_sync(_do)
+        return {
+            "ok": True,
+            "uuid": target_uuid,
+            "name": rec.name,
+            "created": created_via_force,
+            "sample_count": rec.sample_count,
+        }
+
+    def _uuid_for_track(self, track_id: int) -> Optional[str]:
+        """Return the UUID currently assigned to a track, or None."""
+        if self.face_tracker is None:
+            return None
+        idents = self.face_tracker.get_track_identities()
+        rec = idents.get(track_id)
+        if rec is None:
+            return None
+        return rec.get("uuid")
+
+    # ==================================================================
+    # /gallery/forget_last
+    # ==================================================================
+
+    def _handle_gallery_forget_last(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Soft-delete the most recently enrolled UUID. O(1).
+
+        Payload (optional)
+        ------------------
+        uuid : str — if provided, must match last_enrollment.uuid (safety)
+
+        With UUID gallery, forget is a single rename to ``_trash/<uuid>/`` —
+        no GPU work, no rebuild. Use ``/gallery/restore`` to undo, or
+        ``/gallery/empty_trash`` / ``/gallery/delete`` to commit.
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+
+        payload = payload or {}
         with self.enrollment_lock:
             le = self.last_enrollment
             if le is None:
                 return {"error": "no_recent_enrollment"}
             if time.monotonic() - le["monotonic_ts"] > 60.0:
                 return {"error": "stale_enrollment"}
+            target_uuid = le["uuid"]
+            target_name = le["name"]
 
-            target_id = le["id"]
-            files = list(le["files"])
-
-            if "id" in payload:
-                requested = str(payload["id"]).strip().lower()
-                if requested != target_id:
+            if "uuid" in payload:
+                if str(payload["uuid"]).strip() != target_uuid:
                     return {
-                        "error": "id_mismatch",
-                        "detail": f"last enrollment was {target_id}",
+                        "error": "uuid_mismatch",
+                        "detail": f"last enrollment was {target_uuid}",
                     }
 
-        safe_files = self._filter_safe_paths(files)
-        if not safe_files:
-            return {"error": "no_safe_files"}
+        def _do():
+            ok = self.gallery.forget(target_uuid)
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return ok, len(uuids)
 
         t0 = time.monotonic()
-        deleted, identity_removed, n_id = self.run_job_sync(
-            lambda: self._do_forget_files(target_id, safe_files)
-        )
-
+        ok, n_id = self.run_job_sync(_do)
         with self.enrollment_lock:
             self.last_enrollment = None
 
+        # Record for /restore convenience
+        if ok:
+            self.last_soft_deleted = target_uuid
+
+        self._audit_log(f"forget_last uuid={target_uuid} name={target_name}")
         return {
-            "ok": True,
-            "id": target_id,
-            "files_deleted": int(deleted),
-            "identity_removed": bool(identity_removed),
+            "ok": ok,
+            "uuid": target_uuid,
+            "name": target_name,
             "identities": int(n_id),
             "took_sec": round(time.monotonic() - t0, 3),
         }
 
-    def _do_forget_files(
-        self, target_id: str, files: List[str]
-    ) -> "tuple[int, bool, int]":
-        """Main-thread worker for /gallery/forget_last."""
-        deleted = 0
-        for rel in files:
-            path = os.path.join(self.gallery_dir, rel)
-            if os.path.isfile(path):
+    # ==================================================================
+    # /gallery/restore
+    # ==================================================================
+
+    def _handle_gallery_restore(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Restore a UUID from ``_trash/`` back to the active gallery.
+
+        If no UUID is given, defaults to the most recently soft-deleted UUID
+        (set by ``/gallery/delete`` without ``permanent=true``, or by
+        ``/gallery/forget_last``).
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+        payload = payload or {}
+        uuid = str(payload.get("uuid", "")).strip()
+        if not uuid:
+            # Default to last soft-deleted UUID
+            uuid = self.last_soft_deleted or ""
+            if not uuid:
+                return {
+                    "error": "missing_uuid",
+                    "detail": "no recent soft-delete to restore — pass uuid explicitly",
+                }
+
+        def _do():
+            ok = self.gallery.restore(uuid)
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return ok, len(uuids)
+
+        ok, n_id = self.run_job_sync(_do)
+        if not ok:
+            return {"error": "not_in_trash", "uuid": uuid}
+        # Clear the tracker so subsequent /restore calls without args fail loudly
+        if self.last_soft_deleted == uuid:
+            self.last_soft_deleted = None
+        return {"ok": True, "uuid": uuid, "identities": int(n_id)}
+
+    # ==================================================================
+    # /gallery/delete
+    # ==================================================================
+
+    def _handle_gallery_delete(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Delete one or more identities.
+
+        By default this is a SOFT delete — identities are moved to ``_trash/``
+        and can be brought back with ``/gallery/restore``. To permanently
+        erase from disk, pass ``permanent: true`` (equivalent to forget +
+        empty_trash for those UUIDs).
+
+        Accepts UUIDs (preferred) or names (resolves to all matching UUIDs).
+        Payload forms:
+          {"uuid": "..."}                    # soft-delete one UUID
+          {"uuids": ["...", "..."]}          # soft-delete several
+          {"name": "wendy"}                  # soft-delete all UUIDs named wendy
+          {"names": ["wendy", "alice"]}
+          {"uuid": "...", "permanent": true} # HARD delete (no restore)
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+        payload = payload or {}
+        permanent = bool(payload.get("permanent", False))
+
+        # Collect target UUIDs
+        targets: List[str] = []
+        if "uuid" in payload:
+            targets.append(str(payload["uuid"]).strip())
+        if "uuids" in payload and isinstance(payload["uuids"], list):
+            targets.extend(str(u).strip() for u in payload["uuids"])
+
+        # Resolve names → UUIDs
+        names_in = []
+        if "name" in payload:
+            names_in.append(str(payload["name"]).strip().lower())
+        if "names" in payload and isinstance(payload["names"], list):
+            names_in.extend(str(n).strip().lower() for n in payload["names"])
+        for n in names_in:
+            targets.extend(self.gallery.find_by_name(n))
+
+        # Deduplicate while preserving order
+        seen = set()
+        unique_targets = []
+        for u in targets:
+            if u and u not in seen:
+                seen.add(u)
+                unique_targets.append(u)
+
+        if not unique_targets:
+            return {"error": "no_targets", "detail": "supply uuid/uuids or name/names"}
+
+        def _do():
+            deleted: List[str] = []
+            failed: Dict[str, str] = {}
+            for u in unique_targets:
                 try:
-                    os.remove(path)
-                    deleted += 1
-                except OSError as e:
-                    self.log.warning("failed to remove %s: %s", path, e)
+                    if permanent:
+                        # Hard delete: ensure trashed (no-op if already gone),
+                        # then permanently remove.
+                        self.gallery.forget(u)
+                        purged = self.gallery.hard_delete(u)
+                        if purged:
+                            deleted.append(u)
+                        else:
+                            failed[u] = "not_found"
+                    else:
+                        # Soft delete: move to _trash, restorable.
+                        moved = self.gallery.forget(u)
+                        if moved:
+                            deleted.append(u)
+                        else:
+                            failed[u] = "not_found"
+                except Exception as e:
+                    failed[u] = str(e)
 
-        identity_removed = self._cleanup_empty_identity_dir(target_id)
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return deleted, failed, len(uuids)
 
-        # Rebuild from scratch — refresh() leaves stale entries behind
-        self.gm.clear_and_rebuild()
-        feats, labels = self.gm.get_identity_means()
-        with self.gal_lock:
-            self.gal_state.gal_feats = feats
-            self.gal_state.gal_labels = labels
+        t0 = time.monotonic()
+        deleted, failed, n_id = self.run_job_sync(_do)
+
+        # Record last soft-deleted UUID for /restore convenience.
+        # For multi-delete, last in the list wins (most recent).
+        # Hard delete clears it (those UUIDs are unrecoverable).
+        if not permanent and deleted:
+            self.last_soft_deleted = deleted[-1]
+        elif permanent:
+            # If any of the hard-deleted UUIDs was our restore target, clear.
+            if self.last_soft_deleted in deleted:
+                self.last_soft_deleted = None
 
         self._audit_log(
-            f"forget {target_id} files={len(files)} deleted={deleted} "
-            f"identity_removed={identity_removed}"
+            f"delete uuids={deleted} failed={list(failed.keys())} "
+            f"permanent={permanent}"
         )
-        return deleted, identity_removed, len(labels)
+        return {
+            "ok": len(failed) == 0,
+            "deleted": deleted,
+            "failed": failed or None,
+            "identities": int(n_id),
+            "permanent": permanent,
+            "restorable": (not permanent) and len(deleted) > 0,
+            "took_sec": round(time.monotonic() - t0, 3),
+        }
 
-    # -------------------- helpers --------------------- #
-    def _filter_safe_paths(self, rel_paths: List[Any]) -> List[str]:
+    # ==================================================================
+    # /gallery/empty_trash
+    # ==================================================================
+
+    def _handle_gallery_empty_trash(self) -> Dict[str, Any]:
+        """Permanently delete everything in ``_trash/``."""
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+        n = self.run_job_sync(lambda: self.gallery.empty_trash())
+        # After emptying trash, nothing is restorable
+        self.last_soft_deleted = None
+        self._audit_log(f"empty_trash removed={n}")
+        return {"ok": True, "removed": int(n)}
+
+    # ==================================================================
+    # /gallery/merge
+    # ==================================================================
+
+    def _handle_gallery_merge(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge ``source_uuid``'s samples into ``target_uuid``, soft-delete source.
+
+        Use case: an anonymous auto-enrolled UUID turns out to be someone
+        already in the gallery (e.g. same person, different angles or
+        lighting). After confirmation (typically via LLM dialog with the
+        person on screen), call this to fold the two UUIDs into one.
+
+        This is an EXPLICIT operation — there's no automatic merge anywhere
+        in the system. Face similarity alone is not reliable enough to
+        merge without confirmation, since misidentification at this stage
+        is hard to undo (sample embeddings get mixed).
+
+        Payload
+        -------
+        source_uuid  : str (required)  — UUID whose samples will be folded in.
+                                         This UUID is soft-deleted (movable to _trash).
+        target_uuid  : str (required)  — UUID that absorbs source's samples.
+                                         Survives with combined samples + centroid.
+        confirmed_by : str (optional)  — Free-form note about how the merge
+                                         was confirmed (e.g. "llm_dialog",
+                                         "operator", "user_confirmed").
+                                         Logged for audit; not validated.
+
+        Returns
+        -------
+        ok            : bool
+        uuid          : str   — target_uuid (winner)
+        merged_from   : str   — source_uuid (soft-deleted)
+        samples_merged: int   — number of samples added to target
+        sim           : float — pre-merge centroid sim (for audit/debug)
+        identities    : int   — total identities remaining
+
+        Errors
+        ------
+        - missing_uuids        — source_uuid or target_uuid missing
+        - same_uuid            — source == target
+        - uuid_not_found       — either UUID isn't in the gallery
         """
-        Return only the relative paths that resolve to inside gallery_dir.
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
 
-        Path-traversal guard for /gallery/move_samples (where `files` may
-        come from a payload). Rejects absolute paths, `../` escapes, and
-        anything pointing outside the gallery root.
-        """
-        safe: List[str] = []
-        base = os.path.abspath(self.gallery_dir) + os.sep
-        for rel in rel_paths:
-            if not isinstance(rel, str) or not rel:
-                continue
-            abs_path = os.path.abspath(os.path.join(self.gallery_dir, rel))
-            if not (abs_path + os.sep).startswith(base):
-                self.log.warning("rejecting path traversal attempt: %s", rel)
-                continue
-            safe.append(rel)
-        return safe
+        payload = payload or {}
+        source_uuid = str(payload.get("source_uuid", "")).strip()
+        target_uuid = str(payload.get("target_uuid", "")).strip()
+        confirmed_by = str(payload.get("confirmed_by", "")).strip()
 
-    def _cleanup_empty_identity_dir(self, identity: str) -> bool:
-        """
-        Remove identity_dir and its empty subfolders. Returns True if removed.
-        Conservative: leaves the folder alone if anything (e.g. raw/*.jpg)
-        is still in it.
-        """
-        id_dir = os.path.join(self.gallery_dir, identity)
-        if not os.path.isdir(id_dir):
-            return False
+        if not source_uuid or not target_uuid:
+            return {
+                "error": "missing_uuids",
+                "detail": "both source_uuid and target_uuid required",
+            }
+        if source_uuid == target_uuid:
+            return {"error": "same_uuid"}
 
-        for sub in ("aligned", "raw"):
-            sub_dir = os.path.join(id_dir, sub)
-            if os.path.isdir(sub_dir) and not os.listdir(sub_dir):
-                try:
-                    os.rmdir(sub_dir)
-                except OSError:
-                    pass
+        src_rec = self.gallery.get_record(source_uuid)
+        tgt_rec = self.gallery.get_record(target_uuid)
+        if src_rec is None:
+            return {"error": "uuid_not_found", "uuid": source_uuid, "role": "source"}
+        if tgt_rec is None:
+            return {"error": "uuid_not_found", "uuid": target_uuid, "role": "target"}
 
+        # Pre-merge sim (informational — we do NOT gate on it; the caller
+        # already confirmed they want to merge).
+        pre_sim = 0.0
+        sc = src_rec.centroid_normalized
+        tc = tgt_rec.centroid_normalized
+        if sc is not None and tc is not None:
+            pre_sim = float(sc @ tc)
+
+        def _do():
+            n = self.gallery.merge_into(source_uuid, target_uuid)
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return n, len(uuids)
+
+        t0 = time.monotonic()
         try:
-            if not os.listdir(id_dir):
-                os.rmdir(id_dir)
-                return True
-        except OSError:
-            pass
-        return False
+            samples_merged, n_id = self.run_job_sync(_do)
+        except KeyError as e:
+            return {"error": "uuid_not_found", "detail": str(e)}
+
+        # Source is now in _trash — make it restorable via /gallery/restore
+        self.last_soft_deleted = source_uuid
+
+        self._audit_log(
+            f"gallery_merge source={source_uuid} target={target_uuid} "
+            f"samples={samples_merged} sim={pre_sim:.3f} "
+            f"confirmed_by={confirmed_by or '<unspecified>'}"
+        )
+
+        return {
+            "ok": True,
+            "uuid": target_uuid,
+            "merged_from": source_uuid,
+            "samples_merged": int(samples_merged),
+            "sim": round(pre_sim, 3),
+            "identities": int(n_id),
+            "took_sec": round(time.monotonic() - t0, 3),
+        }
+
+    # ==================================================================
+    # /gallery/find_similar
+    # ==================================================================
+
+    def _handle_gallery_find_similar(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Find the top-K most similar gallery UUIDs to a given UUID's centroid.
+
+        Use case: LLM sees an anonymous auto-enrolled UUID and wants to know
+        "do we already have someone in the gallery who looks similar?"
+        Returns sorted candidates with cosine sims so the LLM can decide
+        whether to prompt the user for confirmation:
+
+          "Are you Sean? You look familiar (we have a match at 0.48)."
+
+        Payload
+        -------
+        uuid     : str (required)             — UUID to compare from
+        top_k    : int (optional, default 3)  — number of candidates to return
+        min_sim  : float (optional, default 0.0)  — filter out matches below this
+
+        Returns
+        -------
+        ok      : bool
+        uuid    : str                     — the query UUID (echo)
+        matches : list of {uuid, name, sim, sample_count, source}
+                  Sorted by sim descending. Excludes the query UUID itself.
+
+        Note: returns 0 matches when gallery has only the query UUID, or
+        when all other UUIDs fall below min_sim.
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+
+        payload = payload or {}
+        uuid = str(payload.get("uuid", "")).strip()
+        try:
+            top_k = int(payload.get("top_k", 3))
+        except (TypeError, ValueError):
+            return {"error": "bad_top_k"}
+        try:
+            min_sim = float(payload.get("min_sim", 0.0))
+        except (TypeError, ValueError):
+            return {"error": "bad_min_sim"}
+
+        if not uuid:
+            return {"error": "missing_uuid"}
+        if top_k < 1:
+            return {"error": "bad_top_k", "detail": "top_k must be >= 1"}
+
+        query_rec = self.gallery.get_record(uuid)
+        if query_rec is None:
+            return {"error": "uuid_not_found", "uuid": uuid}
+
+        query_centroid = query_rec.centroid_normalized
+        if query_centroid is None:
+            return {
+                "error": "no_centroid",
+                "detail": "query UUID has no embeddings",
+                "uuid": uuid,
+            }
+
+        # Compare against every other UUID. O(N) over gallery — fine for
+        # demo-scale (~50-100 identities). For larger galleries this could
+        # be vectorized via get_centroids() once, but not needed now.
+        all_records = self.gallery.list_identities(include_unnamed=True)
+        candidates: List[Dict[str, Any]] = []
+        for rec_dict in all_records:
+            cand_uuid = rec_dict["uuid"]
+            if cand_uuid == uuid:
+                continue
+            cand_rec = self.gallery.get_record(cand_uuid)
+            if cand_rec is None or cand_rec.centroid_normalized is None:
+                continue
+            sim = float(query_centroid @ cand_rec.centroid_normalized)
+            if sim < min_sim:
+                continue
+            candidates.append(
+                {
+                    "uuid": cand_uuid,
+                    "name": cand_rec.name,
+                    "sim": round(sim, 3),
+                    "sample_count": cand_rec.sample_count,
+                    "source": cand_rec.metadata.get("source", ""),
+                }
+            )
+
+        # Sort by sim descending, take top_k
+        candidates.sort(key=lambda c: c["sim"], reverse=True)
+        candidates = candidates[:top_k]
+
+        return {
+            "ok": True,
+            "uuid": uuid,
+            "matches": candidates,
+        }
+
+    # ==================================================================
+    # Helpers
+    # ==================================================================
 
     def _audit_log(self, msg: str) -> None:
         """Append a timestamped line to gallery_dir/corrections.log."""
-        log_path = os.path.join(self.gallery_dir, "corrections.log")
+        if not self.gallery_dir:
+            return
+        log_path = osp.join(self.gallery_dir, "corrections.log")
         ts = time.strftime("%Y-%m-%dT%H:%M:%S")
         try:
             with self.audit_lock:
@@ -1060,25 +1431,7 @@ class HttpAPI:
     def _load_112(
         image_path: Optional[str], image_b64: Optional[str]
     ) -> Optional[np.ndarray]:
-        """Load an image from path or base64 and ensure size is 112×112.
-
-        Parameters
-        ----------
-        image_path : str, optional
-            Filesystem path to an image. If provided, takes precedence.
-        image_b64 : str, optional
-            Base64-encoded JPEG/PNG bytes (URL-safe or standard).
-
-        Returns
-        -------
-        np.ndarray or None
-            BGR image of shape `(112, 112, 3)` on success; otherwise `None`.
-
-        Notes
-        -----
-        This helper performs minimal validation and resizing; callers should do
-        additional checks (e.g., identity label existence) as needed.
-        """
+        """Load an image from path or base64 and ensure size is 112×112."""
         img = None
         if image_path:
             img = cv2.imread(image_path)

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/http_api.py
@@ -226,6 +226,8 @@ class HttpAPI:
             # Gallery: identity lifecycle
             if path == "/set_name":
                 return self._handle_set_name(payload)
+            if path == "/set_name_current":
+                return self._handle_set_name_current(payload)
             if path == "/gallery/forget_last":
                 return self._handle_gallery_forget_last(payload)
             if path == "/gallery/restore":
@@ -1031,6 +1033,81 @@ class HttpAPI:
             "name": rec.name,
             "created": created_via_force,
             "sample_count": rec.sample_count,
+        }
+
+    # ==================================================================
+    # /set_name_current — rename whoever is currently in front of camera
+    # ==================================================================
+    def _handle_set_name_current(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Rename the largest currently-visible face.
+
+        Resolves the on-screen face to its UUID server-side (same
+        ``_get_current_largest_face_uuid`` used by merge_current /
+        find_similar_current), then renames THAT UUID. Targeting by face
+        instead of by name means it works even when several identities
+        share a display name ("two Wendys") -- the LLM never has to
+        disambiguate and never passes a UUID.
+
+        Unlike merge_current, this DELIBERATELY allows renaming a face
+        that is already named (wendy -> yucheng is the whole point).
+
+        It is a pure metadata rename (gallery.set_name + label refresh),
+        so it does NOT run the selfie enroll pipeline and never returns
+        ``face_belongs_to``.
+
+        Payload
+        -------
+        name         : str (required) -- new display name
+        confirmed_by : str (optional) -- audit string (e.g. "user_voice")
+
+        Returns
+        -------
+        {ok, uuid, name, prev_name, sample_count, resolved_by} on success.
+        Errors: recognition_disabled | bad_name | no_visible_face |
+                uuid_not_found
+        """
+        if self.gallery is None:
+            return {"error": "recognition_disabled"}
+
+        payload = payload or {}
+        new_name = str(payload.get("name", "")).strip().lower()
+        ok, reason = sl.validate_identity_name(new_name)
+        if not ok:
+            return {"error": "bad_name", "detail": reason}
+
+        # Resolve the target by FACE, not by name.
+        face = self._get_current_largest_face_uuid()
+        if face is None:
+            return {"error": "no_visible_face"}
+        target_uuid = face["uuid"]
+        prev_name = face.get("name") or ""
+
+        if self.gallery.get_record(target_uuid) is None:
+            # In-memory frame had a UUID whose record is gone (e.g. deleted
+            # underneath a running server). Surface it instead of crashing.
+            return {"error": "uuid_not_found", "uuid": target_uuid}
+
+        def _do():
+            # Pure rename: update rec.name + metadata.json on disk...
+            self.gallery.set_name(target_uuid, new_name)
+            # ...then refresh the in-memory recognition labels so the very
+            # next /who poll renders the new name. Same idiom as
+            # _handle_set_name.
+            feats, labels, uuids = self.gallery.get_centroids()
+            with self.gal_lock:
+                self.gal_state.gal_feats = feats
+                self.gal_state.gal_labels = labels
+                self.gal_state.gal_uuids = uuids
+            return self.gallery.get_record(target_uuid)
+
+        rec = self.run_job_sync(_do)
+        return {
+            "ok": True,
+            "uuid": target_uuid,
+            "name": rec.name if rec is not None else new_name,
+            "prev_name": prev_name,
+            "sample_count": rec.sample_count if rec is not None else 0,
+            "resolved_by": "set_name_current",
         }
 
     def _uuid_for_track(self, track_id: int) -> Optional[str]:

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -176,6 +176,9 @@ class _FrameState:
         Detection array of shape (N, 5) with [x1, y1, x2, y2, score], or None.
     kpss : np.ndarray | None
         Optional 5-point landmarks per detection, shape (N, 5, 2), or None.
+    last_ts : float
+        Monotonic timestamp of the last commit. Used by `/selfie` to detect
+        frame changes between taps (so it doesn't re-process the same frame).
     """
 
     def __init__(self):
@@ -184,6 +187,7 @@ class _FrameState:
         self.kpss: Optional[np.ndarray] = None
         self.current_faces: list = []
         self.current_unknowns: list = []
+        self.last_ts: float = 0.0
 
 
 def get_platform_prefix() -> str:
@@ -600,6 +604,33 @@ def main() -> None:
         "draw_skeleton": bool(args.draw_skeleton),
         "draw_pose_boxes": bool(args.draw_pose_boxes),
         "draw_fall_status": bool(args.draw_fall_status),
+        # ---- Selfie pipeline (all hot-tunable via /config) ----
+        # Collection window
+        "selfie_window_sec": 1.5,
+        "selfie_tap_interval_sec": 0.20,
+        # Adaptive sample count: min=1 lets static users still enroll
+        # with just the first valid frame; max=4 caps active users to keep
+        # storage and embedding work bounded.
+        "selfie_min_samples": 1,
+        "selfie_max_samples": 4,
+        # Selection: score = (bbox_area / frame_area) * frontality, in [0,1].
+        # Floor 0.005 = "face covers ~0.5% of frame AND is reasonably frontal".
+        # CALIBRATE on GTC footage; see notes in selfie_logic.score_face docstring.
+        "selfie_min_engagement": 0.015,
+        "selfie_ambiguity_ratio": 0.80,  # top2/top1 > this → ambiguous
+        # Quality gate on the chosen face crop
+        "selfie_min_face_px": 70,
+        "selfie_min_conf": 0.7,
+        "selfie_min_frontality": 0.4,
+        "selfie_sharp_thr": 50.0,
+        "selfie_brightness_min": 40,
+        "selfie_brightness_max": 220,
+        # Multi-frame
+        "selfie_novelty_thr": 0.95,  # cosine > → duplicate, skip
+        "selfie_consistency_thr": 0.50,  # cosine < → wrong person, skip
+        # Dedup
+        "selfie_merge_thr": 0.45,  # same-name family → merge
+        "selfie_cross_name_thr": 0.60,  # cross-name → reject (unless force)
     }
 
     # Last clean frame & detections for /selfie
@@ -769,6 +800,7 @@ def main() -> None:
                 frame_state.frame_bgr = frame.copy()
                 frame_state.dets = None if dets is None else dets.copy()
                 frame_state.kpss = None if kpss is None else kpss.copy()
+                frame_state.last_ts = time.monotonic()
 
             # ---- Track-based recognition (BoTSORT + low-freq AdaFace) ----
             names: List[Optional[str]] = []

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -616,20 +616,20 @@ def main() -> None:
         # Selection: score = (bbox_area / frame_area) * frontality, in [0,1].
         # Floor 0.005 = "face covers ~0.5% of frame AND is reasonably frontal".
         # CALIBRATE on GTC footage; see notes in selfie_logic.score_face docstring.
-        "selfie_min_engagement": 0.015,
+        "selfie_min_engagement": 0.005,
         "selfie_ambiguity_ratio": 0.80,  # top2/top1 > this → ambiguous
         # Quality gate on the chosen face crop
         "selfie_min_face_px": 70,
-        "selfie_min_conf": 0.7,
+        "selfie_min_conf": 0.4,
         "selfie_min_frontality": 0.4,
-        "selfie_sharp_thr": 50.0,
-        "selfie_brightness_min": 40,
-        "selfie_brightness_max": 220,
+        "selfie_sharp_thr": 5.0,
+        "selfie_brightness_min": 30,
+        "selfie_brightness_max": 230,
         # Multi-frame
-        "selfie_novelty_thr": 0.95,  # cosine > → duplicate, skip
+        "selfie_novelty_thr": 0.93,  # cosine > → duplicate, skip
         "selfie_consistency_thr": 0.50,  # cosine < → wrong person, skip
         # Dedup
-        "selfie_merge_thr": 0.45,  # same-name family → merge
+        "selfie_merge_thr": 0.5,  # same-name family → merge
         "selfie_cross_name_thr": 0.60,  # cross-name → reject (unless force)
     }
 

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Real-time face anonymization + recognition + RTSP + HTTP control.
 
@@ -679,6 +678,58 @@ def main() -> None:
                 gal_state.gal_labels = labels
                 gal_state.gal_uuids = uuids
 
+        # Auto-merge on identity flip (vision side only — gallery + tracker
+        # state; memory is intentionally NOT remapped). When one continuous
+        # track flips from one CONFIDENT uuid to another, the two are very
+        # likely the same person (frontal vs profile). Policy: never merge two
+        # NAMED identities; otherwise merge the unknown into the named, or
+        # (both unknown) keep the larger/older and drop the other. Runs on the
+        # recognition thread, same as auto-enroll commits; merge_into soft-
+        # deletes the loser to _trash (undoable), and _refresh_gal_state +
+        # the per-frame set_gallery reconcile the tracker (drop loser row,
+        # re-recognize its tracks onto the survivor).
+        def _is_named(rec) -> bool:
+            n = getattr(rec, "name", "") or ""
+            return bool(n) and not n.lower().startswith("anon")
+
+        def _on_identity_flip(track_id: int, old_uuid: str, new_uuid: str) -> None:
+            try:
+                old_rec = gallery.get_record(old_uuid)
+                new_rec = gallery.get_record(new_uuid)
+                if old_rec is None or new_rec is None:
+                    return  # one already merged/deleted — idempotent no-op
+                old_named = _is_named(old_rec)
+                new_named = _is_named(new_rec)
+                if old_named and new_named:
+                    logger.info(
+                        "identity flip %s<->%s: both named, NOT merging",
+                        old_uuid[:8],
+                        new_uuid[:8],
+                    )
+                    return
+                if old_named:  # unknown(new) -> known(old)
+                    survivor, loser = old_uuid, new_uuid
+                elif new_named:  # unknown(old) -> known(new)
+                    survivor, loser = new_uuid, old_uuid
+                else:  # both unknown: keep larger/older
+                    if getattr(new_rec, "sample_count", 0) > getattr(
+                        old_rec, "sample_count", 0
+                    ):
+                        survivor, loser = new_uuid, old_uuid
+                    else:
+                        survivor, loser = old_uuid, new_uuid
+                merged = gallery.merge_into(loser, survivor)  # source -> target
+                logger.info(
+                    "identity flip: merged %s into %s (%d samples) [track %d]",
+                    loser[:8],
+                    survivor[:8],
+                    merged,
+                    track_id,
+                )
+                _refresh_gal_state()
+            except Exception as e:
+                logger.warning("identity-flip merge failed: %s", e)
+
         # Auto-enroller fires the refresh callback on commit so face_tracker's
         # gallery snapshot picks up the new identity within one frame.
         auto_enroller = AutoEnroller(
@@ -690,6 +741,8 @@ def main() -> None:
             min_face_pixels=int(args.auto_enroll_min_face_px),
             merge_thr=float(args.auto_enroll_merge_thr),
             on_committed=lambda u, t, n: _refresh_gal_state(),
+            min_conf=float(config.AUTO_ENROLL_MIN_CONF),
+            min_frontality=float(config.AUTO_ENROLL_MIN_FRONTALITY),
         )
         logger.info(
             "AutoEnroller initialized (N=%d, tightness=%.2f, min_unknown=%.1fs, merge_thr=%.2f)",
@@ -704,6 +757,8 @@ def main() -> None:
             # Wire face_tracker's per-track recognition stream into the
             # auto-enroller. Fires once per track per recognition pass.
             face_tracker.on_unknown_sample = auto_enroller.observe
+            # Auto-merge fragmented identities when a track flips confident UUID.
+            face_tracker.on_identity_flip = _on_identity_flip
 
             # Continuous sample refresh: on every confident per-frame
             # match, the refresh manager decides (via 3 guards) whether

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -3,25 +3,37 @@
 Real-time face anonymization + recognition + RTSP + HTTP control.
 
 This program captures video from a V4L2 camera, detects faces (SCRFD, TensorRT),
-optionally recognizes them (ArcFace, TensorRT) using an on-disk gallery managed by
-`GalleryManager`, applies privacy pixelation (all / known / unknown), and publishes
-the processed video to RTSP (local and/or remote). A lightweight HTTP control plane
-lets you query presence (/who), tweak runtime config (/config), and update the gallery
-(/gallery/refresh, /gallery/add_aligned, /gallery/add_raw, /selfie), all while the
-main video loop keeps running.
+optionally recognizes them (AdaFace, TensorRT) against a UUID-keyed on-disk
+gallery (``UUIDGallery``), applies privacy pixelation (all / known / unknown),
+and publishes the processed video to RTSP (local and/or remote).
+
+A lightweight HTTP control plane (``HttpAPI``) lets you query presence
+(/who), tweak runtime config (/config), enroll identities (/selfie,
+/gallery/add_aligned, /gallery/add_raw), rename them (/set_name), and
+manage lifecycle (/gallery/forget_last, /gallery/restore, /gallery/delete,
+/gallery/empty_trash) while the main video loop keeps running.
+
+Background auto-enrollment (``AutoEnroller``) silently builds UUIDs for
+unknown faces that linger in view long enough — the LLM only needs to
+*name* identities via /set_name, not create them. This shifts the slow
+multi-frame collection work off the LLM-facing critical path.
 
 - Detection: SCRFD (TensorRT)
-- Recognition: ArcFace (TensorRT) via GalleryManager (incremental refresh)
+- Recognition: AdaFace (TensorRT), 3-tier (confident/tentative/uncertain)
+- Storage: UUIDGallery (per-identity self-contained folders; O(1) renames
+  and deletes; one-shot migration of the legacy name-keyed layout on
+  startup)
 - Privacy: pixelation (all / known / unknown)
 - Streaming: RTSP (local; remote relay handled by MediaMTX/FFmpeg)
-- HTTP: /who, /config (get/set), /gallery/refresh, /gallery/add_aligned,
-        /gallery/add_raw, /selfie, /ping, /ts
+- HTTP: /who, /config, /selfie, /set_name, /gallery/{refresh,identities,
+        add_aligned,add_raw,forget_last,restore,delete,empty_trash,
+        auto_enroll_status}, /ping, /ts
 
 Usage examples
 --------------
-# Minimal (local RTSP only)
+# Minimal (local RTSP only) — Unitree G1 onboard camera (640x480 @ 15fps)
 python -m om1_vlm.anonymizationSys.face_recog_stream.run \
-  --device /dev/video0 --width 1280 --height 720 --fps 30 \
+  --device /dev/video0 --width 640 --height 480 --fps 15 \
   --detection --recognition --blur --blur-mode all \
   --draw-boxes --draw-names --show-fps \
   --http-host 0.0.0.0 --http-port 6791
@@ -31,7 +43,7 @@ python -m om1_vlm.anonymizationSys.face_recog_stream.run \
   --scrfd-engine /home/openmind/Documents/OM1-modules/src/om1_vlm/anonymizationSys/engine/scrfd_10g.engine \
   --arc-engine /home/openmind/Documents/OM1-modules/src/om1_vlm/anonymizationSys/engine/adaface_ir101.engine \
   --size 640 --device /dev/video0 \
-  --width 1920 --height 1080 --fps 30 \
+  --width 1920 --height 1080 --fps 15 \
   --detection --recognition \
   --draw-boxes --draw-names --show-fps \
   --http-host 0.0.0.0 --http-port 6791 \
@@ -128,13 +140,15 @@ import numpy as np
 
 from om1_utils.http import Server  # lightweight HTTP server
 
+from . import config
 from .adaface import TRTFaceRecognition
+from .auto_enroller import AutoEnroller
 from .camera_reader import CameraReader
 from .draw import draw_overlays
 from .draw_pose import draw_fall_alert, draw_pose_overlays
 from .face_tracker import FaceTracker
 from .fall_detector import FallDetector
-from .gallery import GalleryManager
+from .gallery import UUIDGallery
 from .http_api import HttpAPI
 from .rtsp_video_writer import RTSPVideoStreamWriter
 from .scrfd import TRTSCRFD
@@ -154,12 +168,20 @@ class _GalState:
         Stacked, L2-normalized per-identity mean vectors (N_id × dim) used for
         cosine similarity at runtime. May be None if the gallery is empty.
     gal_labels : list[str]
-        Identity labels aligned with `gal_feats` rows.
+        Display names parallel to ``gal_feats`` rows. Multiple rows may share
+        the same name (e.g. one person enrolled via selfie and again via
+        auto-enroll). UUIDs are the stable identifier; names are mutable
+        metadata.
+    gal_uuids : list[str]
+        Stable identity UUIDs parallel to ``gal_feats`` / ``gal_labels``.
+        Always use UUIDs for cross-component identity references (HttpAPI's
+        ``/set_name``, ``/gallery/forget_last``, audit log entries, etc.).
     """
 
     def __init__(self):
         self.gal_feats: Optional[np.ndarray] = None
         self.gal_labels: List[str] = []
+        self.gal_uuids: List[str] = []
 
 
 class _FrameState:
@@ -213,7 +235,8 @@ def main() -> None:
     ----
     1) Parse CLI args and resolve default paths.
     2) Load TensorRT engines (SCRFD detector, optional ArcFace).
-    3) Build/refresh gallery via `GalleryManager` and cache identity means.
+    3) Build/refresh gallery via `UUIDGallery`, migrate legacy data if any,
+       initialize `AutoEnroller`, and cache identity centroids.
     4) Open camera (`CameraReader`) and start RTSP writer.
     5) Initialize shared states, locks, and an HTTP `HttpAPI` bound to a tiny
        `Server` that runs on its own thread.
@@ -238,7 +261,7 @@ def main() -> None:
     logger.info("Starting realtime_stream...")
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    models_dir = os.path.join(script_dir, "..", "engines")
+    models_dir = os.path.join(script_dir, "..", "engine")
 
     platform_prefix = get_platform_prefix()
     scrfd_name = f"{platform_prefix}_scrfd_10g.engine"
@@ -295,13 +318,9 @@ def main() -> None:
         "--gallery",
         dest="gallery_dir",
         default=default_gallery,
-        help="Gallery root (subfolders per identity). Required if --recognition.",
-    )
-    ap.add_argument(
-        "--embeds-dir",
-        dest="embeds_dir",
-        default=None,
-        help="Embeddings root. Default is sibling of gallery, e.g. /path/to/embeds for gallery /path/to/gallery.",
+        help="Gallery root directory. In UUID mode, contains one folder per "
+        "identity (UUID-named) plus _legacy/ (migration archive) and "
+        "_trash/ (soft-deleted UUIDs). Required if --recognition.",
     )
 
     # Features
@@ -382,28 +401,112 @@ def main() -> None:
         help="If detected faces exceed this, skip recognition (still blur/draw).",
     )
 
-    # Thresholds
+    # Thresholds — defaults come from config.py for single-source-of-truth
     ap.add_argument(
-        "--conf", type=float, default=0.5, help="Detection confidence threshold."
+        "--conf",
+        type=float,
+        default=config.DETECTION_CONFIDENCE,
+        help="Detection confidence threshold. See config.DETECTION_CONFIDENCE.",
     )
-    ap.add_argument("--nms", type=float, default=0.4, help="NMS IoU threshold.")
+    ap.add_argument(
+        "--nms",
+        type=float,
+        default=config.DETECTION_NMS,
+        help="NMS IoU threshold. See config.DETECTION_NMS.",
+    )
     ap.add_argument(
         "--sim-thr",
         type=float,
-        default=0.55,
-        help="Recognition cosine similarity threshold.",
+        default=config.SIM_THR,
+        help="Recognition cosine similarity threshold (top-1 floor). "
+        "See config.SIM_THR for calibration notes.",
     )
     ap.add_argument(
-        "--max-num", type=int, default=0, help="Max faces to keep (0 = no limit)."
+        "--strict-margin",
+        type=float,
+        default=config.STRICT_MARGIN,
+        help="top1-top2 margin for 'confident' tier. See config.STRICT_MARGIN.",
+    )
+    ap.add_argument(
+        "--loose-margin",
+        type=float,
+        default=config.LOOSE_MARGIN,
+        help="top1-top2 margin for 'tentative' tier. Must be < strict-margin. "
+        "See config.LOOSE_MARGIN.",
+    )
+
+    # Auto-enrollment — defaults from config.py
+    ap.add_argument(
+        "--auto-enroll-min-samples",
+        type=int,
+        default=config.AUTO_ENROLL_MIN_SAMPLES,
+        help="Samples needed before auto-enroll commits a new UUID. "
+        "See config.AUTO_ENROLL_MIN_SAMPLES.",
+    )
+    ap.add_argument(
+        "--auto-enroll-max-buffer",
+        type=int,
+        default=config.AUTO_ENROLL_MAX_BUFFER,
+        help="Max samples per track buffer. See config.AUTO_ENROLL_MAX_BUFFER.",
+    )
+    ap.add_argument(
+        "--auto-enroll-tightness",
+        type=float,
+        default=config.AUTO_ENROLL_TIGHTNESS,
+        help="Worst pairwise cosine sim across buffer. "
+        "See config.AUTO_ENROLL_TIGHTNESS.",
+    )
+    ap.add_argument(
+        "--auto-enroll-min-unknown-sec",
+        type=float,
+        default=config.AUTO_ENROLL_MIN_UNKNOWN_SEC,
+        help="Min seconds track-visible before enrolling. "
+        "See config.AUTO_ENROLL_MIN_UNKNOWN_SEC.",
+    )
+    ap.add_argument(
+        "--auto-enroll-min-face-px",
+        type=int,
+        default=config.AUTO_ENROLL_MIN_FACE_PX,
+        help="Min bbox short side for auto-enroll. "
+        "See config.AUTO_ENROLL_MIN_FACE_PX.",
+    )
+    ap.add_argument(
+        "--auto-enroll-merge-thr",
+        type=float,
+        default=config.AUTO_ENROLL_MERGE_THR,
+        help="Merge buffer into existing UUID if buffer mean sim ≥ this "
+        "(instead of creating new). Catches 'known person, bad lighting' "
+        "case. 0.0 disables. See config.AUTO_ENROLL_MERGE_THR.",
+    )
+    ap.add_argument(
+        "--max-num",
+        type=int,
+        default=config.DETECTION_MAX_NUM,
+        help="Max faces to keep (0 = no limit). See config.DETECTION_MAX_NUM.",
     )
 
     # Inputs
     ap.add_argument(
         "--device", default="/dev/video0", help="V4L2 device (e.g., /dev/video0)"
     )
-    ap.add_argument("--width", type=int, default=640, help="Capture width.")
-    ap.add_argument("--height", type=int, default=480, help="Capture height.")
-    ap.add_argument("--fps", type=int, default=30, help="Capture frame rate.")
+    ap.add_argument(
+        "--width",
+        type=int,
+        default=config.CAMERA_WIDTH,
+        help=f"Capture width. Default {config.CAMERA_WIDTH} (Unitree G1 onboard camera).",
+    )
+    ap.add_argument(
+        "--height",
+        type=int,
+        default=config.CAMERA_HEIGHT,
+        help=f"Capture height. Default {config.CAMERA_HEIGHT}.",
+    )
+    ap.add_argument(
+        "--fps",
+        type=int,
+        default=config.CAMERA_FPS,
+        help=f"Capture frame rate. Default {config.CAMERA_FPS} (Unitree G1 onboard camera).",
+    )
 
     # Outputs
     ap.add_argument(
@@ -448,20 +551,15 @@ def main() -> None:
 
     args = ap.parse_args()
 
-    # Resolve default embeds_dir if not provided
-    if args.embeds_dir is None:
-        parent = os.path.dirname(os.path.abspath(args.gallery_dir))
-        args.embeds_dir = os.path.join(parent, "embeds")
-
     # Sanity checks
     if not os.path.exists(args.scrfd_engine):
         raise SystemExit(f"SCRFD engine not found: {args.scrfd_engine}")
     if args.recognition:
         if not os.path.exists(args.arc_engine):
             raise SystemExit(f"ArcFace engine not found: {args.arc_engine}")
-        if not os.path.exists(args.gallery_dir):
-            raise SystemExit(f"Gallery directory not found: {args.gallery_dir}")
-        os.makedirs(args.embeds_dir, exist_ok=True)
+        # Auto-create gallery_dir on first run rather than failing — first-time
+        # users shouldn't need to mkdir before launching.
+        os.makedirs(args.gallery_dir, exist_ok=True)
     if args.pose and not os.path.exists(args.pose_engine):
         raise SystemExit(f"Pose engine not found: {args.pose_engine}")
 
@@ -486,17 +584,27 @@ def main() -> None:
     if args.recognition and arc is not None:
         face_tracker = FaceTracker(
             arc=arc,
-            recog_interval=0.2,  # run AdaFace every 0.2s per unidentified track
-            vote_frames=3,  # collect 3 votes before deciding
-            vote_threshold=0.5,  # majority vote (2/3)
-            max_recog_attempts=10,
+            recog_interval=config.RECOG_INTERVAL_SEC,
+            vote_frames=config.VOTE_FRAMES,
+            vote_threshold=config.VOTE_THRESHOLD,
+            max_recog_attempts=config.MAX_RECOG_ATTEMPTS,
             sim_thr=float(args.sim_thr),
-            track_buffer=60,
+            strict_margin=float(args.strict_margin),
+            loose_margin=float(args.loose_margin),
+            track_buffer=config.TRACK_BUFFER,
             arc_max_bs=arc_max_bs,
             det_conf=float(args.conf),
-            re_identify_interval=1.0,  # retry unknown tracks every 1s
+            re_identify_interval=config.RE_IDENTIFY_INTERVAL_SEC,
         )
-        logger.info("FaceTracker initialized (BoTSORT + low-freq AdaFace)")
+        logger.info(
+            "FaceTracker initialized (sim_thr=%.2f, strict_margin=%.2f, "
+            "loose_margin=%.2f, track_buffer=%d frames, re_identify=%.1fs)",
+            args.sim_thr,
+            args.strict_margin,
+            args.loose_margin,
+            config.TRACK_BUFFER,
+            config.RE_IDENTIFY_INTERVAL_SEC,
+        )
 
     # Load pose detection engine
     pose_detector: Optional[TRTYOLOPose] = None
@@ -525,31 +633,75 @@ def main() -> None:
     # Gallery state + lock
     gal_state = _GalState()
     gal_lock = threading.Lock()
-    gm: Optional[GalleryManager] = None
+    gallery: Optional[UUIDGallery] = None
+    auto_enroller: Optional[AutoEnroller] = None
 
     if args.recognition:
-        gm = GalleryManager(
-            gallery_dir=args.gallery_dir,
-            embeds_dir=args.embeds_dir,
-            arc=arc,  # type: ignore[arg-type]
-            scrfd=scrfd,
-            det_conf=args.conf,
-        )
-        t0b = time.time()
-        aligned_added, vec_added = gm.refresh(process_raw=True)
-        feats, id_labels = gm.get_identity_means()
+        gallery = UUIDGallery(args.gallery_dir, arc=arc)  # type: ignore[arg-type]
+
+        # One-shot migration: old name-keyed folders → UUID dirs. Idempotent
+        # (no-op when gallery already in UUID format). Originals are archived
+        # under gallery_dir/_legacy/ — not deleted — in case rollback is needed.
+        if gallery.has_legacy_data():
+            t_mig = time.time()
+            n_migrated = gallery.migrate_legacy()
+            logger.info(
+                "Migrated %d legacy identities to UUID format in %.1fs",
+                n_migrated,
+                time.time() - t_mig,
+            )
+
+        # Initial centroid snapshot for the main loop
+        feats, id_labels, id_uuids = gallery.get_centroids()
         with gal_lock:
-            gal_state.gal_feats, gal_state.gal_labels = feats, id_labels
+            gal_state.gal_feats = feats
+            gal_state.gal_labels = id_labels
+            gal_state.gal_uuids = id_uuids
         logger.info(
-            "Gallery ready: identities=%d (aligned+%d, vectors+%d) time=%.2fs",
-            len(id_labels),
-            aligned_added,
-            vec_added,
-            time.time() - t0b,
+            "Gallery ready: identities=%d (path=%s)",
+            len(id_uuids),
+            args.gallery_dir,
         )
+
+        # Helper called by AutoEnroller after a successful auto-commit, and
+        # implicitly used elsewhere too — keeps gal_state in lockstep with
+        # gallery's on-disk state. Cheap: just reads centroids from memory.
+        def _refresh_gal_state() -> None:
+            feats, labels, uuids = gallery.get_centroids()
+            with gal_lock:
+                gal_state.gal_feats = feats
+                gal_state.gal_labels = labels
+                gal_state.gal_uuids = uuids
+
+        # Auto-enroller fires the refresh callback on commit so face_tracker's
+        # gallery snapshot picks up the new identity within one frame.
+        auto_enroller = AutoEnroller(
+            gallery,
+            n_samples_required=int(args.auto_enroll_min_samples),
+            max_buffer=int(args.auto_enroll_max_buffer),
+            min_pairwise_sim=float(args.auto_enroll_tightness),
+            min_unknown_sec=float(args.auto_enroll_min_unknown_sec),
+            min_face_pixels=int(args.auto_enroll_min_face_px),
+            merge_thr=float(args.auto_enroll_merge_thr),
+            on_committed=lambda u, t, n: _refresh_gal_state(),
+        )
+        logger.info(
+            "AutoEnroller initialized (N=%d, tightness=%.2f, min_unknown=%.1fs, merge_thr=%.2f)",
+            args.auto_enroll_min_samples,
+            args.auto_enroll_tightness,
+            args.auto_enroll_min_unknown_sec,
+            args.auto_enroll_merge_thr,
+        )
+
         if face_tracker is not None:
-            face_tracker.set_gallery(feats, id_labels)
-            logger.info("FaceTracker gallery synced: %d identities", len(id_labels))
+            face_tracker.set_gallery(feats, id_labels, id_uuids)
+            # Wire face_tracker's per-track recognition stream into the
+            # auto-enroller. Fires once per track per recognition pass.
+            face_tracker.on_unknown_sample = auto_enroller.observe
+            logger.info(
+                "FaceTracker gallery synced: %d identities; auto-enroll hook wired",
+                len(id_uuids),
+            )
 
     # Capture
     cap = CameraReader(args.device, args.width, args.height, args.fps)
@@ -583,55 +735,34 @@ def main() -> None:
     # Who tracking
     who = WhoTracker(lookback_sec=args.http_lookback_sec)
 
-    # Runtime config (HTTP-settable)
+    # Runtime config (HTTP-settable). Seeded from config.DEFAULTS, with CLI
+    # flags overriding any keys they shadow. See config.py for canonical
+    # parameter definitions, docs, and hot-tunability notes.
     cfg_lock = threading.Lock()
-    cfg: Dict[str, Any] = {
-        "blur": bool(args.blur),
-        "blur_mode": str(args.blur_mode),
-        "sim_thr": float(args.sim_thr),
-        "crowd_thr": int(args.crowd_thr),
-        "show_fps": bool(args.show_fps),
-        "conf": float(args.conf),
-        "nms": float(args.nms),
-        "max_num": int(args.max_num),
-        "pixel_blocks": int(args.pixel_blocks),
-        "pixel_margin": float(args.pixel_margin),
-        "pixel_noise": float(args.pixel_noise),
-        "pose": bool(args.pose),
-        "pose_conf": 0.5,
-        "pose_max_num": 10,
-        "fall_detection": bool(args.fall_detection),
-        "draw_skeleton": bool(args.draw_skeleton),
-        "draw_pose_boxes": bool(args.draw_pose_boxes),
-        "draw_fall_status": bool(args.draw_fall_status),
-        # ---- Selfie pipeline (all hot-tunable via /config) ----
-        # Collection window
-        "selfie_window_sec": 0.8,
-        "selfie_tap_interval_sec": 0.10,
-        # Adaptive sample count: min=1 lets static users still enroll
-        # with just the first valid frame; max=4 caps active users to keep
-        # storage and embedding work bounded.
-        "selfie_min_samples": 1,
-        "selfie_max_samples": 4,
-        # Selection: score = (bbox_area / frame_area) * frontality, in [0,1].
-        # Floor 0.005 = "face covers ~0.5% of frame AND is reasonably frontal".
-        # CALIBRATE on GTC footage; see notes in selfie_logic.score_face docstring.
-        "selfie_min_engagement": 0.005,
-        "selfie_ambiguity_ratio": 0.80,  # top2/top1 > this → ambiguous
-        # Quality gate on the chosen face crop
-        "selfie_min_face_px": 70,
-        "selfie_min_conf": 0.4,
-        "selfie_min_frontality": 0.4,
-        "selfie_sharp_thr": 5.0,
-        "selfie_brightness_min": 30,
-        "selfie_brightness_max": 230,
-        # Multi-frame
-        "selfie_novelty_thr": 0.93,  # cosine > → duplicate, skip
-        "selfie_consistency_thr": 0.50,  # cosine < → wrong person, skip
-        # Dedup
-        "selfie_merge_thr": 0.5,  # same-name family → merge
-        "selfie_cross_name_thr": 0.60,  # cross-name → reject (unless force)
-    }
+    cfg: Dict[str, Any] = dict(config.DEFAULTS)
+    # CLI overrides — let --flag values override config defaults at startup.
+    cfg.update(
+        {
+            "blur": bool(args.blur),
+            "blur_mode": str(args.blur_mode),
+            "sim_thr": float(args.sim_thr),
+            "strict_margin": float(args.strict_margin),
+            "loose_margin": float(args.loose_margin),
+            "crowd_thr": int(args.crowd_thr),
+            "show_fps": bool(args.show_fps),
+            "conf": float(args.conf),
+            "nms": float(args.nms),
+            "max_num": int(args.max_num),
+            "pixel_blocks": int(args.pixel_blocks),
+            "pixel_margin": float(args.pixel_margin),
+            "pixel_noise": float(args.pixel_noise),
+            "pose": bool(args.pose),
+            "fall_detection": bool(args.fall_detection),
+            "draw_skeleton": bool(args.draw_skeleton),
+            "draw_pose_boxes": bool(args.draw_pose_boxes),
+            "draw_fall_status": bool(args.draw_fall_status),
+        }
+    )
 
     # Last clean frame & detections for /selfie
     frame_state = _FrameState()
@@ -707,7 +838,8 @@ def main() -> None:
     http_api = HttpAPI(
         who=who,
         scrfd=scrfd,
-        gm=gm,
+        gallery=gallery,
+        auto_enroller=auto_enroller,
         gallery_dir=args.gallery_dir,
         gal_state=gal_state,
         gal_lock=gal_lock,
@@ -769,6 +901,8 @@ def main() -> None:
                 do_blur = bool(cfg["blur"])
                 blur_mode = str(cfg["blur_mode"])
                 sim_thr = float(cfg["sim_thr"])
+                strict_margin = float(cfg["strict_margin"])
+                loose_margin = float(cfg["loose_margin"])
                 show_fps = bool(cfg["show_fps"])
                 det_conf = float(cfg["conf"])
                 max_num = int(cfg["max_num"])
@@ -810,9 +944,15 @@ def main() -> None:
                 with gal_lock:
                     if gal_state.gal_feats is not None:
                         face_tracker.set_gallery(
-                            gal_state.gal_feats, gal_state.gal_labels
+                            gal_state.gal_feats,
+                            gal_state.gal_labels,
+                            gal_state.gal_uuids,
                         )
-                face_tracker.set_sim_thr(sim_thr)
+                face_tracker.set_thresholds(
+                    sim_thr=sim_thr,
+                    strict_margin=strict_margin,
+                    loose_margin=loose_margin,
+                )
 
                 # Always call update so BoTSORT ages out lost tracks on empty frames
                 track_results = face_tracker.update(frame, dets, kpss)
@@ -823,9 +963,16 @@ def main() -> None:
                     frame_state.current_unknowns = face_tracker.get_unknowns()
 
                 if dets is not None and dets.shape[0] > 0:
-                    # Map track results back to detection indices (exclusive matching)
+                    # Map track results back to detection indices.
+                    # We keep three parallel arrays aligned with dets:
+                    #   names         — formatted display string (for drawing)
+                    #   raw_names     — plain identity label (for tracking layers)
+                    #   tiers         — confidence tier (for tracking layers)
+                    #   known_mask    — True iff tier == "confident" (for blur policy)
                     n_det = dets.shape[0]
                     names = ["unknown"] * n_det
+                    raw_names: List[Optional[str]] = [None] * n_det
+                    tiers: List[Optional[str]] = [None] * n_det
                     known_mask = [False] * n_det
                     used_dets = set()  # prevent double assignment
 
@@ -855,32 +1002,31 @@ def main() -> None:
                         if best_d >= 0 and best_iou > 0.3:
                             used_dets.add(best_d)
                             names[best_d] = tr.name
+                            raw_names[best_d] = tr.raw_name
+                            tiers[best_d] = tr.tier
                             known_mask[best_d] = tr.is_known
                 else:
                     n = 0 if dets is None else int(dets.shape[0])
                     names = ["unknown"] * n
+                    raw_names = [None] * n
+                    tiers = [None] * n
                     known_mask = [False] * n
             else:
                 n = 0 if dets is None else int(dets.shape[0])
                 names = ["unknown"] * n
+                raw_names = [None] * n
+                tiers = [None] * n
                 known_mask = [False] * n
 
-            # Who-tracker (strip score suffix)
-            # Strip score suffix helper
-            def strip_score(nm: Optional[str]) -> Optional[str]:
-                if nm is None:
-                    return None
-                if nm == "unknown":
-                    return "unknown"
-                # Handle "wendy? (0.62)" and "wendy (0.65)"
-                p = nm.find("? (")
-                if p > 0:
-                    return nm[:p]  # strip "? (score)"
-                p = nm.find(" (")
-                return nm[:p] if p > 0 else nm
-
-            # Strip scores from names for tracking
-            names_stripped = [strip_score(nm) for nm in names]
+            # raw_names already contains plain identity labels (no score suffix)
+            # straight from TrackResult.raw_name. Convert None → "unknown" for
+            # consumers that expect string entries (fall match, who tracker).
+            names_for_tracking: List[str] = [
+                (n if n is not None else "unknown") for n in raw_names
+            ]
+            # tiers parallel-aligned with names_for_tracking. None entries mean
+            # "no tier info" — WhoTracker treats as uncertain for confident/
+            # tentative aggregation.
 
             # Pose detection + fall detection (BEFORE who.update_now)
             pose_dets: Optional[np.ndarray] = None
@@ -907,15 +1053,28 @@ def main() -> None:
                             fall_statuses=fall_statuses,
                             pose_keypoints=pose_kps,
                             face_bboxes=dets,
-                            face_names=names_stripped,
+                            face_names=names_for_tracking,
                         )
 
                 except Exception as e:
                     logger.warning("[warn] pose detection failed: %s", e)
                     pose_dets, pose_kps = None, None
 
-            # Update who tracker WITH fall info (AFTER fall detection)
-            who.update_now(names_stripped, fall_infos=fall_infos)
+            # Update who tracker WITH tier + fall info
+            who.update_now(names_for_tracking, tiers=tiers, fall_infos=fall_infos)
+
+            # AutoEnroller maintenance, every ~1 second (15 frames @ 15fps):
+            #   1. try_commit_pending — proactively commits buffers whose
+            #      gates have all passed since the last observe() call.
+            #      Without this, a track that went status="unknown" with a
+            #      ripe buffer would have to wait for re-identify (~1s)
+            #      before its UUID is created.
+            #   2. gc_stale — drops buffers for tracks BoTSORT stopped
+            #      reporting.
+            # Both ops are cheap (small dict scans).
+            if auto_enroller is not None and total % 15 == 0:
+                auto_enroller.try_commit_pending()
+                auto_enroller.gc_stale()
 
             # Draw Pose (BEFORE blur)
             if pose_dets is not None and len(pose_dets) > 0:

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -637,6 +637,7 @@ def main() -> None:
     auto_enroller: Optional[AutoEnroller] = None
 
     if args.recognition:
+        assert arc is not None
         gallery = UUIDGallery(  # type: ignore[arg-type]
             args.gallery_dir,
             arc=arc,
@@ -1141,7 +1142,7 @@ def main() -> None:
             # raw_names already contains plain identity labels (no score suffix)
             # straight from TrackResult.raw_name. Convert None → "unknown" for
             # consumers that expect string entries (fall match, who tracker).
-            names_for_tracking: List[str] = [
+            names_for_tracking: List[Optional[str]] = [
                 (n if n is not None else "unknown") for n in raw_names
             ]
             # tiers parallel-aligned with names_for_tracking. None entries mean

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -606,8 +606,8 @@ def main() -> None:
         "draw_fall_status": bool(args.draw_fall_status),
         # ---- Selfie pipeline (all hot-tunable via /config) ----
         # Collection window
-        "selfie_window_sec": 1.5,
-        "selfie_tap_interval_sec": 0.20,
+        "selfie_window_sec": 0.8,
+        "selfie_tap_interval_sec": 0.10,
         # Adaptive sample count: min=1 lets static users still enroll
         # with just the first valid frame; max=4 caps active users to keep
         # storage and embedding work bounded.

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/run.py
@@ -151,6 +151,7 @@ from .fall_detector import FallDetector
 from .gallery import UUIDGallery
 from .http_api import HttpAPI
 from .rtsp_video_writer import RTSPVideoStreamWriter
+from .sample_refresh import SampleRefreshManager
 from .scrfd import TRTSCRFD
 from .who_tracker import WhoTracker, match_falls_to_faces
 from .yolo_pose import TRTYOLOPose
@@ -637,7 +638,12 @@ def main() -> None:
     auto_enroller: Optional[AutoEnroller] = None
 
     if args.recognition:
-        gallery = UUIDGallery(args.gallery_dir, arc=arc)  # type: ignore[arg-type]
+        gallery = UUIDGallery(  # type: ignore[arg-type]
+            args.gallery_dir,
+            arc=arc,
+            max_samples_per_uuid=config.MAX_SAMPLES_PER_UUID,
+            last_seen_persist_interval_sec=config.LAST_SEEN_DISK_PERSIST_INTERVAL_SEC,
+        )
 
         # One-shot migration: old name-keyed folders → UUID dirs. Idempotent
         # (no-op when gallery already in UUID format). Originals are archived
@@ -698,8 +704,67 @@ def main() -> None:
             # Wire face_tracker's per-track recognition stream into the
             # auto-enroller. Fires once per track per recognition pass.
             face_tracker.on_unknown_sample = auto_enroller.observe
+
+            # Continuous sample refresh: on every confident per-frame
+            # match, the refresh manager decides (via 3 guards) whether
+            # to fold the embedding into the matched UUID. This keeps
+            # the gallery's centroids enriched with new angles/lighting
+            # over long-running sessions, without polluting named
+            # identities (sample misattributions are filtered out by
+            # the diversity guard).
+            refresh_mgr = SampleRefreshManager(
+                gallery,
+                sim_thr=float(args.sim_thr),
+                min_extra_confidence=config.REFRESH_MIN_EXTRA_CONFIDENCE,
+                min_refresh_interval_sec=config.REFRESH_MIN_INTERVAL_SEC,
+                min_diversity_sim=config.REFRESH_MIN_DIVERSITY_SIM,
+                max_diversity_sim=config.REFRESH_MAX_DIVERSITY_SIM,
+            )
+
+            def _on_confident(track_id, uuid, crop, embedding, sim):
+                """face_tracker → refresh_mgr bridge.
+
+                Two side-effects per confident match:
+
+                1. If this is the FIRST confident match for this track,
+                   snapshot the gallery's current ``last_seen_at`` into
+                   ``ident.session_last_seen_iso`` — captures the
+                   PREVIOUS session's last sighting before we overwrite
+                   it. This becomes the "we've met before" signal for
+                   the LLM downstream.
+
+                2. ``gallery.touch_last_seen(uuid)`` updates the
+                   gallery's metadata to "now" so long-term cleanup
+                   sweeps know this UUID is active.
+
+                3. Conditional refresh_mgr.observe applies the 3 guards
+                   to decide whether to fold this embedding into the
+                   centroid.
+                """
+                now_mono = time.monotonic()
+
+                # 1. Snapshot previous last_seen on FIRST confident hit
+                #    (no-op on subsequent frames in same session).
+                if face_tracker.get_session_last_seen(track_id) is None:
+                    rec = gallery.get_record(uuid)
+                    if rec is not None:
+                        prev_iso = rec.metadata.get("last_seen_at") or rec.metadata.get(
+                            "created_at"
+                        )
+                        face_tracker.maybe_set_session_last_seen(track_id, prev_iso)
+
+                # 2. Touch — gallery's last_seen_at = now
+                gallery.touch_last_seen(uuid)
+
+                # 3. Refresh if guards allow
+                if refresh_mgr.should_refresh(uuid, sim, now_mono):
+                    refresh_mgr.observe(uuid, crop, embedding, now_mono, sim=sim)
+
+            face_tracker.on_confident_sample = _on_confident
+
             logger.info(
-                "FaceTracker gallery synced: %d identities; auto-enroll hook wired",
+                "FaceTracker gallery synced: %d identities; "
+                "auto-enroll + refresh hooks wired",
                 len(id_uuids),
             )
 

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/sample_refresh.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/sample_refresh.py
@@ -1,0 +1,159 @@
+"""Continuous-refresh manager for the face gallery.
+
+When a track is confidently identified, the recognized embedding may add
+new feature diversity to the known UUID's centroid — e.g. a different
+angle, lighting, or expression. Folding these into the gallery makes
+recognition more robust over time.
+
+Guards (defense against polluting a named identity with misattributions):
+
+  A. Match confidence — caller verifies tier == confident AND sim is well
+     above ``sim_thr`` (sim_thr + ``min_extra_confidence``) before calling.
+  B. Per-UUID rate limit — at most one refresh attempt per
+     ``min_refresh_interval_sec`` per UUID. Prevents a single session
+     from flooding a UUID with near-identical samples and prevents the
+     refresh path from dominating CPU.
+  C. Diversity check — applied inside ``gallery.refresh_sample``: the new
+     sample's sim to centroid must be in ``[min_diversity_sim,
+     max_diversity_sim]``. Skips near-duplicates and likely
+     misidentifications.
+
+The gallery itself enforces the FIFO sample cap (``max_samples_per_uuid``)
+so disk doesn't grow unboundedly even with permissive guard settings.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+import numpy as np
+
+log = logging.getLogger(__name__)
+
+
+class SampleRefreshManager:
+    """Stateful helper that decides when to call ``gallery.refresh_sample``.
+
+    Holds the per-UUID rate-limit state (Guard B). Guard A (sim threshold)
+    is a constructor parameter; Guard C (diversity) is delegated to the
+    gallery.
+
+    Wire into the main loop after recognition runs. For each track that's
+    been confidently identified this frame::
+
+        if refresh_mgr.should_refresh(uuid, sim, now):
+            refresh_mgr.observe(uuid, crop, embedding, now)
+    """
+
+    def __init__(
+        self,
+        gallery,
+        *,
+        sim_thr: float = 0.55,
+        min_extra_confidence: float = 0.10,
+        min_refresh_interval_sec: float = 10.0,
+        min_diversity_sim: float = 0.65,
+        max_diversity_sim: float = 0.92,
+    ) -> None:
+        self.gallery = gallery
+        # Guard A threshold: only refresh when sim >= sim_thr + min_extra
+        self.refresh_thr = float(sim_thr) + float(min_extra_confidence)
+        # Guard B: min seconds between refresh attempts per UUID
+        self.min_refresh_interval_sec = float(min_refresh_interval_sec)
+        # Guard C parameters (passed through to gallery.refresh_sample)
+        self.min_diversity_sim = float(min_diversity_sim)
+        self.max_diversity_sim = float(max_diversity_sim)
+
+        # Per-UUID monotonic timestamp of the LAST refresh ATTEMPT (success
+        # or skip — once we try, we wait the interval before trying again).
+        # This prevents a long-lived track from spamming the gallery.
+        self._last_attempt: Dict[str, float] = {}
+
+        # Counters for /gallery/auto_enroll_status-style introspection.
+        self.attempts = 0
+        self.refreshed = 0
+        self.skipped_low_sim = 0  # Guard A failure
+        self.skipped_rate_limit = 0  # Guard B failure
+        self.skipped_diversity = 0  # Guard C failure (from gallery)
+
+    def set_sim_thr(self, sim_thr: float, min_extra_confidence: float = 0.10) -> None:
+        """Hot-update Guard A threshold (e.g. when ``/config`` changes sim_thr)."""
+        self.refresh_thr = float(sim_thr) + float(min_extra_confidence)
+
+    def should_refresh(self, uuid: str, sim: float, now: float) -> bool:
+        """Cheap pre-check before computing whether to actually call
+        ``gallery.refresh_sample``. Returns True only if Guards A + B pass.
+
+        Guard C is checked inside ``observe``/``gallery.refresh_sample``
+        because it needs the embedding (more expensive).
+        """
+        if not uuid:
+            return False
+        # Guard A
+        if sim < self.refresh_thr:
+            return False
+        # Guard B
+        last = self._last_attempt.get(uuid, 0.0)
+        if (now - last) < self.min_refresh_interval_sec:
+            return False
+        return True
+
+    def observe(
+        self,
+        uuid: str,
+        crop: np.ndarray,
+        embedding: np.ndarray,
+        now: float,
+        sim: Optional[float] = None,
+    ) -> bool:
+        """Run a refresh attempt. Returns True if a sample was actually added,
+        False otherwise. Always marks the UUID as "tried at ``now``" for
+        rate-limiting (so a flood of low-quality observations doesn't
+        bypass Guard B).
+        """
+        if not uuid:
+            return False
+        self.attempts += 1
+        self._last_attempt[uuid] = now
+
+        # Re-check Guard A here too in case caller bypassed should_refresh
+        if sim is not None and sim < self.refresh_thr:
+            self.skipped_low_sim += 1
+            return False
+
+        try:
+            added = self.gallery.refresh_sample(
+                uuid,
+                crop,
+                embedding,
+                min_diversity_sim=self.min_diversity_sim,
+                max_diversity_sim=self.max_diversity_sim,
+            )
+        except Exception as e:
+            log.warning("refresh observe: gallery.refresh_sample raised: %s", e)
+            return False
+
+        if added:
+            self.refreshed += 1
+        else:
+            # gallery.refresh_sample logs the specific reason
+            self.skipped_diversity += 1
+        return added
+
+    def snapshot(self) -> dict:
+        """Diagnostic snapshot for /gallery/refresh_status (or debug logs)."""
+        return {
+            "refresh_thr": round(self.refresh_thr, 3),
+            "min_refresh_interval_sec": self.min_refresh_interval_sec,
+            "diversity_range": [
+                round(self.min_diversity_sim, 3),
+                round(self.max_diversity_sim, 3),
+            ],
+            "attempts": self.attempts,
+            "refreshed": self.refreshed,
+            "skipped_low_sim": self.skipped_low_sim,
+            "skipped_rate_limit": self.skipped_rate_limit,
+            "skipped_diversity": self.skipped_diversity,
+            "tracked_uuids": len(self._last_attempt),
+        }

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
@@ -325,17 +325,11 @@ def update_running_mean(
     return (out / norm).astype(np.float32, copy=False)
 
 
-def cosine_to_mean(running_mean: Optional[np.ndarray], new_v: np.ndarray) -> float:
+def cosine_to_mean(running_mean: np.ndarray, new_v: np.ndarray) -> float:
     """
     Cosine similarity. Both inputs assumed unit-norm.
 
     Used for BOTH novelty (skip frames too similar to running mean)
     AND identity consistency (reject frames too different from collected so far).
-
-    Returns 0.0 if running_mean is None (no frames accepted yet). This is a
-    defensive default — call sites only invoke this after a first frame has
-    been accepted, so None shouldn't happen, but typing makes it possible.
     """
-    if running_mean is None:
-        return 0.0
     return float(np.dot(running_mean, new_v))

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
@@ -325,11 +325,17 @@ def update_running_mean(
     return (out / norm).astype(np.float32, copy=False)
 
 
-def cosine_to_mean(running_mean: np.ndarray, new_v: np.ndarray) -> float:
+def cosine_to_mean(running_mean: Optional[np.ndarray], new_v: np.ndarray) -> float:
     """
     Cosine similarity. Both inputs assumed unit-norm.
 
     Used for BOTH novelty (skip frames too similar to running mean)
     AND identity consistency (reject frames too different from collected so far).
+
+    Returns 0.0 if running_mean is None (no frames accepted yet). This is a
+    defensive default — call sites only invoke this after a first frame has
+    been accepted, so None shouldn't happen, but typing makes it possible.
     """
+    if running_mean is None:
+        return 0.0
     return float(np.dot(running_mean, new_v))

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
@@ -1,0 +1,335 @@
+"""
+Pure logic for the selfie enrollment pipeline.
+
+Stateless. All shared state (gallery, frame_state, cfg) is owned by HttpAPI
+and passed in by parameter. No GPU work happens here; embeddings are computed
+elsewhere (main thread via run_job_sync) and passed in.
+
+Place at: src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import cv2
+import numpy as np
+
+# 5-point landmark indices (SCRFD / RetinaFace convention).
+# These are subject-perspective: subject's left eye, subject's right eye,
+# nose, subject's left mouth, subject's right mouth.
+EYE_A_IDX = 0
+EYE_B_IDX = 1
+NOSE_IDX = 2
+
+_VALID_ID = re.compile(r"^[a-z0-9_-]+$")
+# Reject names ending in _<digits> to avoid colliding with the suffix system.
+# E.g. user-supplied "wendy_1" would confuse next_suffix logic.
+_HAS_SUFFIX = re.compile(r"_\d+$")
+
+
+# Decision objects
+@dataclass
+class DedupDecision:
+    """Outcome of resolve_target_id()."""
+
+    id: Optional[str] = None  # Target folder name on success
+    merged: bool = False  # True if saving into existing folder
+    reject: bool = False  # True if cross-name conflict (no force)
+    match_label: Optional[str] = None  # Closest existing label (for telemetry)
+    match_sim: float = 0.0  # Cosine to closest match
+
+
+# Geometry: frontality from 5-point landmarks
+def frontality(kps: Optional[np.ndarray]) -> float:
+    """
+    Score in [0, 1] of how frontal a face is, from its 5 keypoints.
+
+    1.0 = eyes level AND nose centered between them.
+    0.0 = full profile OR extreme head tilt.
+
+    Robust to detector landmark ordering: we don't rely on which point is the
+    "left" vs "right" eye, only on the geometric relationship between the two
+    eye points and the nose. Absolute values everywhere.
+    """
+    if kps is None or len(kps) < 3:
+        return 0.0
+
+    eye_a = kps[EYE_A_IDX]
+    eye_b = kps[EYE_B_IDX]
+    nose = kps[NOSE_IDX]
+
+    eye_dx = abs(float(eye_b[0]) - float(eye_a[0]))
+    if eye_dx < 1.0:
+        # Degenerate: eyes at near-identical x (extreme angle or detector
+        # malfunction). Cannot meaningfully assess frontality.
+        return 0.0
+
+    # Yaw: how centered is the nose between the two eyes?
+    eye_mid_x = (float(eye_a[0]) + float(eye_b[0])) / 2.0
+    nose_off = (float(nose[0]) - eye_mid_x) / eye_dx
+    yaw_score = max(0.0, 1.0 - 2.0 * abs(nose_off))
+
+    # Roll: how level are the eyes?
+    eye_dy = abs(float(eye_b[1]) - float(eye_a[1]))
+    roll_score = max(0.0, 1.0 - eye_dy / eye_dx)
+
+    return yaw_score * roll_score
+
+
+# Scoring: who is the robot being addressed by?
+def score_face(
+    det: np.ndarray,
+    kps: Optional[np.ndarray],
+    frame_area: float,
+) -> float:
+    """
+    Engagement score in [0, 1] (resolution-independent).
+
+    score = (bbox_area / frame_area) * frontality
+
+    "Engaged" = close (large in frame) AND looking at robot (frontal).
+    Multiplicative — failing either component kills the score, so a huge
+    but turned-away face cannot beat a smaller frontal one.
+
+    Normalizing by frame_area decouples the threshold from camera resolution:
+    a face covering 1% of the frame is the same "size" at 720p and 4K.
+    """
+    if frame_area <= 0:
+        return 0.0
+    x1, y1, x2, y2 = float(det[0]), float(det[1]), float(det[2]), float(det[3])
+    bbox_area = max(0.0, x2 - x1) * max(0.0, y2 - y1)
+    front = frontality(kps) if kps is not None else 0.0
+    return (bbox_area / frame_area) * front
+
+
+# Frame-level filters
+def check_ambiguity(
+    scores: List[float],
+    ratio_thr: float,
+    score_floor: float,
+) -> Tuple[bool, float]:
+    """
+    Detect "who is the target" ambiguity within the current frame.
+
+    Returns (is_ambiguous, top_ratio).
+
+    Ambiguous iff top-1 AND top-2 are BOTH above score_floor (both faces
+    are "engaging") AND top2/top1 > ratio_thr (they're close in engagement).
+
+    Faces below the floor don't count — a small background bystander can't
+    create ambiguity even if their score is close to the target's.
+    """
+    if len(scores) < 2:
+        return False, 0.0
+
+    sorted_desc = sorted(scores, reverse=True)
+    top1, top2 = sorted_desc[0], sorted_desc[1]
+
+    if top1 < score_floor or top2 < score_floor:
+        return False, 0.0
+
+    ratio = top2 / top1 if top1 > 0 else 0.0
+    return ratio > ratio_thr, ratio
+
+
+def quality_check(
+    crop_112: np.ndarray,
+    det: np.ndarray,
+    kps: Optional[np.ndarray],
+    cfg: dict,
+) -> Tuple[bool, str]:
+    """
+    Per-frame quality gate on the selected face.
+
+    Returns (ok, reason). reason is "" on success, otherwise one of:
+    too_small | low_conf | bad_pose | blurry | too_dark | too_bright
+    """
+    x1, y1, x2, y2 = float(det[0]), float(det[1]), float(det[2]), float(det[3])
+    conf = float(det[4]) if len(det) >= 5 else 1.0
+    w, h = x2 - x1, y2 - y1
+
+    if min(w, h) < float(cfg["selfie_min_face_px"]):
+        return False, "too_small"
+
+    if conf < float(cfg["selfie_min_conf"]):
+        return False, "low_conf"
+
+    if kps is not None:
+        if frontality(kps) < float(cfg["selfie_min_frontality"]):
+            return False, "bad_pose"
+
+    gray = cv2.cvtColor(crop_112, cv2.COLOR_BGR2GRAY)
+    if cv2.Laplacian(gray, cv2.CV_64F).var() < float(cfg["selfie_sharp_thr"]):
+        return False, "blurry"
+
+    mb = float(gray.mean())
+    if mb < float(cfg["selfie_brightness_min"]):
+        return False, "too_dark"
+    if mb > float(cfg["selfie_brightness_max"]):
+        return False, "too_bright"
+
+    return True, ""
+
+
+# Identity name handling
+def validate_identity_name(name: str) -> Tuple[bool, str]:
+    """
+    Check identity name format. Returns (ok, reason).
+
+    Rules:
+    - non-empty, ≤32 chars
+    - lowercase alphanumeric, underscore, dash only
+    - must NOT end in `_<digits>` (reserved for suffix system)
+    """
+    if not name:
+        return False, "empty"
+    if len(name) > 32:
+        return False, "too_long"
+    if not _VALID_ID.match(name):
+        return False, "invalid_chars"
+    if _HAS_SUFFIX.search(name):
+        return False, "ends_with_suffix"
+    return True, ""
+
+
+def is_same_root(label: str, root: str) -> bool:
+    """True iff `label` is exactly `root` or `root_<digits>`."""
+    if label == root:
+        return True
+    return bool(re.fullmatch(rf"{re.escape(root)}_\d+", label))
+
+
+def next_suffix(name: str, existing_labels: List[str]) -> str:
+    """
+    Next available label in the {name, name_1, name_2, ...} family.
+
+    - If `name` itself is free → return `name`.
+    - Else return `name_<max_n + 1>` where max_n scans existing `name_<n>` labels.
+    """
+    existing = set(existing_labels)
+    if name not in existing:
+        return name
+
+    pat = re.compile(rf"^{re.escape(name)}_(\d+)$")
+    max_n = 0
+    for label in existing:
+        m = pat.match(label)
+        if m:
+            max_n = max(max_n, int(m.group(1)))
+
+    return f"{name}_{max_n + 1}"
+
+
+# Dedup
+def resolve_target_id(
+    embedding: np.ndarray,
+    requested_name: str,
+    gal_feats: Optional[np.ndarray],
+    gal_labels: List[str],
+    cfg: dict,
+    force: bool = False,
+) -> DedupDecision:
+    """
+    Decide which gallery folder a new face should go into.
+
+    One full-table cosine search, then 2×2 decision matrix on
+    (similarity tier, label-matches-requested-name).
+
+    Thresholds (from cfg):
+    - cross_thr (~0.60): strong cross-name match → reject (unless force)
+    - merge_thr (~0.45): same-name family match → merge into existing folder
+
+    Behavior:
+    - Empty gallery                                    → use requested_name
+    - sim >= cross_thr, same-root label                → merge
+    - sim >= cross_thr, different name, force=False    → REJECT
+    - sim >= cross_thr, different name, force=True     → new with suffix
+    - merge_thr <= sim < cross_thr, same-root          → merge
+    - otherwise                                        → new with suffix
+    """
+    cross_thr = float(cfg["selfie_cross_name_thr"])
+    merge_thr = float(cfg["selfie_merge_thr"])
+
+    if gal_feats is None or len(gal_labels) == 0:
+        return DedupDecision(id=requested_name)
+
+    # gal_feats rows and embedding are both unit-norm
+    sims = gal_feats @ embedding
+    j = int(np.argmax(sims))
+    best_sim = float(sims[j])
+    best_label = gal_labels[j]
+
+    same_root = is_same_root(best_label, requested_name)
+
+    # Strong match
+    if best_sim >= cross_thr:
+        if same_root:
+            return DedupDecision(
+                id=best_label,
+                merged=True,
+                match_label=best_label,
+                match_sim=best_sim,
+            )
+        if force:
+            return DedupDecision(
+                id=next_suffix(requested_name, gal_labels),
+                match_label=best_label,
+                match_sim=best_sim,
+            )
+        return DedupDecision(
+            reject=True,
+            match_label=best_label,
+            match_sim=best_sim,
+        )
+
+    # Soft match to same-root → merge
+    if best_sim >= merge_thr and same_root:
+        return DedupDecision(
+            id=best_label,
+            merged=True,
+            match_label=best_label,
+            match_sim=best_sim,
+        )
+
+    # No qualifying match → new identity (possibly with suffix)
+    return DedupDecision(
+        id=next_suffix(requested_name, gal_labels),
+        match_label=best_label,
+        match_sim=best_sim,
+    )
+
+
+# Multi-frame: running mean + novelty + consistency
+def update_running_mean(
+    current_mean: Optional[np.ndarray],
+    new_v: np.ndarray,
+    new_count: int,
+) -> np.ndarray:
+    """
+    Incremental L2-normalized running mean.
+
+    `new_count` is the count AFTER adding new_v (1, 2, 3, ...).
+    Always returns a unit-norm vector.
+    """
+    if current_mean is None or new_count <= 1:
+        out = new_v.astype(np.float32, copy=True)
+    else:
+        out = current_mean * (new_count - 1) + new_v
+
+    norm = float(np.linalg.norm(out))
+    if norm < 1e-12:
+        return new_v.astype(np.float32, copy=True)
+    return (out / norm).astype(np.float32, copy=False)
+
+
+def cosine_to_mean(running_mean: np.ndarray, new_v: np.ndarray) -> float:
+    """
+    Cosine similarity. Both inputs assumed unit-norm.
+
+    Used for BOTH novelty (skip frames too similar to running mean)
+    AND identity consistency (reject frames too different from collected so far).
+    """
+    return float(np.dot(running_mean, new_v))

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/selfie_logic.py
@@ -25,21 +25,44 @@ EYE_B_IDX = 1
 NOSE_IDX = 2
 
 _VALID_ID = re.compile(r"^[a-z0-9_-]+$")
-# Reject names ending in _<digits> to avoid colliding with the suffix system.
-# E.g. user-supplied "wendy_1" would confuse next_suffix logic.
-_HAS_SUFFIX = re.compile(r"_\d+$")
 
 
 # Decision objects
 @dataclass
 class DedupDecision:
-    """Outcome of resolve_target_id()."""
+    """Outcome of resolve_target_id().
 
-    id: Optional[str] = None  # Target folder name on success
-    merged: bool = False  # True if saving into existing folder
-    reject: bool = False  # True if cross-name conflict (no force)
-    match_label: Optional[str] = None  # Closest existing label (for telemetry)
-    match_sim: float = 0.0  # Cosine to closest match
+    Fields
+    ------
+    uuid : str | None
+        UUID to add samples to. ``None`` means "create a new UUID with
+        ``name``" — caller invokes ``gallery.create(name).
+    name : str
+        Display name to use. For merges, this is the existing UUID's name
+        (may differ in casing from the requested name; we use what's on disk).
+        For new identities, this is the requested name verbatim.
+    merged : bool
+        True iff ``uuid`` is set (we're merging into an existing identity).
+    reject : bool
+        True iff this selfie should be rejected because the face strongly
+        matches a *different* named identity (``match_name``), and
+        ``force=False``. Indicates likely confusion ("are you Bob, not Wendy?").
+    match_name : str | None
+        Best-matching existing display name, for telemetry / user-facing
+        error messages.
+    match_uuid : str | None
+        UUID of the best match (regardless of whether we merged with it).
+    match_sim : float
+        Cosine similarity to the best match.
+    """
+
+    uuid: Optional[str] = None
+    name: str = ""
+    merged: bool = False
+    reject: bool = False
+    match_name: Optional[str] = None
+    match_uuid: Optional[str] = None
+    match_sim: float = 0.0
 
 
 # Geometry: frontality from 5-point landmarks
@@ -135,6 +158,138 @@ def check_ambiguity(
     return ratio > ratio_thr, ratio
 
 
+# ---------------------------------------------------------------------------
+# Recognition: 1:N identification with confidence tiering
+# ---------------------------------------------------------------------------
+
+# Recognition tier names. Exposed so callers don't have to spell strings.
+TIER_CONFIDENT = "confident"
+TIER_TENTATIVE = "tentative"
+TIER_UNCERTAIN = "uncertain"
+
+
+def recognize_from_sims(
+    sims: np.ndarray,
+    gal_labels: List[str],
+    *,
+    min_sim: float,
+    strict_margin: float,
+    loose_margin: float,
+) -> Tuple[str, str, float, float]:
+    """
+    Decide identity from precomputed cosine similarities, with a 3-tier
+    confidence output.
+
+    Use this when you already have ``sims = gal_feats @ query`` (e.g. inside a
+    batched recognition pass). Use ``recognize()`` for one-off queries.
+
+    Decision tree (in order):
+      1. Empty gallery                          → ("unknown", "uncertain")
+      2. top1 sim < min_sim                     → ("unknown", "uncertain")
+      3. top1 - top2 >= strict_margin           → (name, "confident")
+      4. top1 - top2 >= loose_margin            → (name, "tentative")
+      5. otherwise (ambiguous between names)    → ("unknown", "uncertain")
+
+    Why tiered output:
+    - At small gallery (N<50), top1 alone is reliable.
+    - At larger gallery, many near-collisions exist; top1 alone gives false
+      matches. The margin between top1 and top2 is a much better confidence
+      signal than top1 itself.
+    - But a strict margin gate over-filters: a person we *can* recognize will
+      sometimes have margin=0.05 (clearly above zero but below strict). We
+      want to surface that as "tentative" so the caller can ask for
+      verification instead of giving up.
+
+    Parameters
+    ----------
+    sims : ndarray (N_id,)
+        Cosine similarities between the query and each gallery centroid.
+        Assumed both are L2-normalized so this is just a dot product.
+    gal_labels : list[str]
+        Label per row of sims; ``len(gal_labels) == len(sims)``.
+    min_sim : float
+        Minimum top-1 cosine for any match (typical 0.40 - 0.50).
+    strict_margin : float
+        Required ``top1 - top2`` to call it "confident" (typical 0.08 - 0.12).
+    loose_margin : float
+        Required ``top1 - top2`` to call it "tentative" (typical 0.03 - 0.05).
+        Must be strictly less than ``strict_margin``.
+
+    Returns
+    -------
+    (name, tier, top1_sim, top2_sim) : (str, str, float, float)
+        - name: gallery label or ``"unknown"``
+        - tier: one of ``"confident"``, ``"tentative"``, ``"uncertain"``
+        - top1_sim, top2_sim: raw scores for logging / debugging
+          (top2_sim is 0.0 when gallery has only one entry)
+    """
+    if sims is None or len(sims) == 0:
+        return ("unknown", TIER_UNCERTAIN, 0.0, 0.0)
+
+    # Single-entry gallery: no margin to compute, fall back to threshold only.
+    if len(sims) == 1:
+        s1 = float(sims[0])
+        if s1 < min_sim:
+            return ("unknown", TIER_UNCERTAIN, s1, 0.0)
+        return (gal_labels[0], TIER_CONFIDENT, s1, 0.0)
+
+    # General case: find top-1 and top-2.
+    # argpartition is O(N), faster than full sort when we only need top-K.
+    # NOTE: k argument is the index position we want partitioned, not the
+    # number of items. To pick top-2, k=1 is correct (positions 0 and 1 hold
+    # the two smallest of -sims, which are the two largest of sims).
+    # k=2 would crash with "kth out of bounds" when len(sims) == 2.
+    top2_idx = np.argpartition(-sims, 1)[:2]
+    if sims[top2_idx[0]] < sims[top2_idx[1]]:
+        top2_idx = top2_idx[::-1]
+    s1 = float(sims[top2_idx[0]])
+    s2 = float(sims[top2_idx[1]])
+    name = gal_labels[int(top2_idx[0])]
+
+    if s1 < min_sim:
+        return ("unknown", TIER_UNCERTAIN, s1, s2)
+
+    margin = s1 - s2
+    if margin >= strict_margin:
+        return (name, TIER_CONFIDENT, s1, s2)
+    if margin >= loose_margin:
+        return (name, TIER_TENTATIVE, s1, s2)
+    # Ambiguous: two identities tied within `loose_margin`. Better to refuse
+    # than to commit to either. The temporal voting layer will see this as
+    # "uncertain" and not count it toward any name.
+    return ("unknown", TIER_UNCERTAIN, s1, s2)
+
+
+def recognize(
+    embedding: np.ndarray,
+    gal_feats: Optional[np.ndarray],
+    gal_labels: List[str],
+    *,
+    min_sim: float,
+    strict_margin: float,
+    loose_margin: float,
+) -> Tuple[str, str]:
+    """
+    Convenience wrapper around :func:`recognize_from_sims` for callers that
+    only need (name, tier).
+
+    Computes ``sims = gal_feats @ embedding`` internally, then dispatches to
+    ``recognize_from_sims``. Returns ``("unknown", "uncertain")`` for an
+    empty gallery without touching ``gal_feats``.
+    """
+    if gal_feats is None or len(gal_feats) == 0 or len(gal_labels) == 0:
+        return ("unknown", TIER_UNCERTAIN)
+    sims = gal_feats @ embedding
+    name, tier, _, _ = recognize_from_sims(
+        sims,
+        gal_labels,
+        min_sim=min_sim,
+        strict_margin=strict_margin,
+        loose_margin=loose_margin,
+    )
+    return (name, tier)
+
+
 def quality_check(
     crop_112: np.ndarray,
     det: np.ndarray,
@@ -182,7 +337,9 @@ def validate_identity_name(name: str) -> Tuple[bool, str]:
     Rules:
     - non-empty, ≤32 chars
     - lowercase alphanumeric, underscore, dash only
-    - must NOT end in `_<digits>` (reserved for suffix system)
+
+    Note: in the UUID-based gallery there's no suffix collision concern, so
+    names like ``"wendy_2"`` are allowed.
     """
     if not name:
         return False, "empty"
@@ -190,37 +347,7 @@ def validate_identity_name(name: str) -> Tuple[bool, str]:
         return False, "too_long"
     if not _VALID_ID.match(name):
         return False, "invalid_chars"
-    if _HAS_SUFFIX.search(name):
-        return False, "ends_with_suffix"
     return True, ""
-
-
-def is_same_root(label: str, root: str) -> bool:
-    """True iff `label` is exactly `root` or `root_<digits>`."""
-    if label == root:
-        return True
-    return bool(re.fullmatch(rf"{re.escape(root)}_\d+", label))
-
-
-def next_suffix(name: str, existing_labels: List[str]) -> str:
-    """
-    Next available label in the {name, name_1, name_2, ...} family.
-
-    - If `name` itself is free → return `name`.
-    - Else return `name_<max_n + 1>` where max_n scans existing `name_<n>` labels.
-    """
-    existing = set(existing_labels)
-    if name not in existing:
-        return name
-
-    pat = re.compile(rf"^{re.escape(name)}_(\d+)$")
-    max_n = 0
-    for label in existing:
-        m = pat.match(label)
-        if m:
-            max_n = max(max_n, int(m.group(1)))
-
-    return f"{name}_{max_n + 1}"
 
 
 # Dedup
@@ -229,75 +356,124 @@ def resolve_target_id(
     requested_name: str,
     gal_feats: Optional[np.ndarray],
     gal_labels: List[str],
+    gal_uuids: List[str],
     cfg: dict,
     force: bool = False,
 ) -> DedupDecision:
-    """
-    Decide which gallery folder a new face should go into.
+    """Decide whether a new selfie should merge with an existing UUID.
 
-    One full-table cosine search, then 2×2 decision matrix on
-    (similarity tier, label-matches-requested-name).
+    Runs one cosine search against the in-memory centroids, then applies a
+    two-tier decision:
 
-    Thresholds (from cfg):
-    - cross_thr (~0.60): strong cross-name match → reject (unless force)
-    - merge_thr (~0.45): same-name family match → merge into existing folder
+    Thresholds (from ``cfg``)
+    -------------------------
+    ``selfie_cross_name_thr`` (~0.60)
+        Above this, the face is "strongly recognized as someone". If that
+        someone has a different name from the requested one → reject the
+        selfie (suggests user confusion or impersonation). Override with
+        ``force=True``.
+    ``selfie_merge_thr`` (~0.45)
+        Above this AND the matched identity already has the same name →
+        merge (append samples to existing UUID). Below this → create a new
+        UUID even if a similarly-named identity exists.
 
-    Behavior:
-    - Empty gallery                                    → use requested_name
-    - sim >= cross_thr, same-root label                → merge
-    - sim >= cross_thr, different name, force=False    → REJECT
-    - sim >= cross_thr, different name, force=True     → new with suffix
-    - merge_thr <= sim < cross_thr, same-root          → merge
-    - otherwise                                        → new with suffix
+    Behavior matrix
+    ---------------
+    Empty gallery                                       → CREATE NEW UUID
+    sim ≥ cross_thr, same-name match                    → MERGE
+    sim ≥ cross_thr, different name, force=False        → REJECT
+    sim ≥ cross_thr, different name, force=True         → CREATE NEW UUID
+    merge_thr ≤ sim < cross_thr, same-name match        → MERGE
+    otherwise                                           → CREATE NEW UUID
+
+    Multiple UUIDs per name are explicitly allowed (two different selfie
+    sessions for the same person produce two UUIDs; both will match her
+    face). The merge path picks the single best-scoring UUID; future
+    selfies will fold into whichever has the closest centroid.
     """
     cross_thr = float(cfg["selfie_cross_name_thr"])
     merge_thr = float(cfg["selfie_merge_thr"])
+    requested_lower = requested_name.strip().lower()
 
-    if gal_feats is None or len(gal_labels) == 0:
-        return DedupDecision(id=requested_name)
+    if gal_feats is None or len(gal_uuids) == 0:
+        # Brand-new gallery — caller creates a fresh UUID with this name.
+        return DedupDecision(uuid=None, name=requested_name)
 
     # gal_feats rows and embedding are both unit-norm
     sims = gal_feats @ embedding
     j = int(np.argmax(sims))
     best_sim = float(sims[j])
-    best_label = gal_labels[j]
+    best_name = gal_labels[j]
+    best_uuid = gal_uuids[j]
 
-    same_root = is_same_root(best_label, requested_name)
+    # Anonymous UUIDs (name="") are treated as "claimable" — the empty name
+    # matches any requested name. This is the "selfie claims an anon" path:
+    # when face_tracker auto-enrolled this face into UUID X with no name,
+    # a follow-up selfie that matches X should fold into X and name it,
+    # not reject (the old cross-name protection had a false-positive here:
+    # "" ≠ "sean" was treated as a name conflict, blocking the natural
+    # workflow of giving the anon a name).
+    is_anon_match = (not best_name) or (not best_name.strip())
+    same_name = is_anon_match or (best_name.strip().lower() == requested_lower)
 
-    # Strong match
+    # Strong match — face is being recognized as a known identity
     if best_sim >= cross_thr:
-        if same_root:
+        if same_name:
+            # Merging into the matched UUID.
+            # If the match is anon (no name yet), use the REQUESTED name —
+            # the selfie is claiming this anon UUID. The caller will fold
+            # selfie samples in AND rename the UUID. If the match already
+            # has the requested name, keep the existing name (no-op rename).
+            effective_name = requested_name if is_anon_match else best_name
             return DedupDecision(
-                id=best_label,
+                uuid=best_uuid,
+                name=effective_name,
                 merged=True,
-                match_label=best_label,
+                match_name=best_name,
+                match_uuid=best_uuid,
                 match_sim=best_sim,
             )
         if force:
+            # User insists this is a different person despite the strong
+            # match (twin / lookalike). Create a brand-new UUID.
             return DedupDecision(
-                id=next_suffix(requested_name, gal_labels),
-                match_label=best_label,
+                uuid=None,
+                name=requested_name,
+                match_name=best_name,
+                match_uuid=best_uuid,
                 match_sim=best_sim,
             )
+        # Different name without force — reject and surface who we think
+        # this actually is.
         return DedupDecision(
             reject=True,
-            match_label=best_label,
+            match_name=best_name,
+            match_uuid=best_uuid,
             match_sim=best_sim,
         )
 
-    # Soft match to same-root → merge
-    if best_sim >= merge_thr and same_root:
+    # Soft match to same name → merge
+    if best_sim >= merge_thr and same_name:
+        # Same logic as the strong-match same_name branch: use requested
+        # name when claiming an anon UUID, else preserve existing name.
+        effective_name = requested_name if is_anon_match else best_name
         return DedupDecision(
-            id=best_label,
+            uuid=best_uuid,
+            name=effective_name,
             merged=True,
-            match_label=best_label,
+            match_name=best_name,
+            match_uuid=best_uuid,
             match_sim=best_sim,
         )
 
-    # No qualifying match → new identity (possibly with suffix)
+    # No qualifying match → create new UUID. Note: requested_name might
+    # already exist as a different UUID's name; that's fine, names are
+    # not unique in the UUID gallery.
     return DedupDecision(
-        id=next_suffix(requested_name, gal_labels),
-        match_label=best_label,
+        uuid=None,
+        name=requested_name,
+        match_name=best_name,
+        match_uuid=best_uuid,
         match_sim=best_sim,
     )
 

--- a/src/om1_vlm/anonymizationSys/face_recog_stream/who_tracker.py
+++ b/src/om1_vlm/anonymizationSys/face_recog_stream/who_tracker.py
@@ -120,92 +120,198 @@ def match_falls_to_faces(
 
 
 # ------------------------------- Who Tracker ------------------------------- #
+
+# Tier constants — kept in sync with selfie_logic.recognize_from_sims to avoid
+# magic strings in this module.
+TIER_CONFIDENT = "confident"
+TIER_TENTATIVE = "tentative"
+TIER_UNCERTAIN = "uncertain"
+
+
 class WhoTracker:
-    """Tracks identities seen now and over a short lookback window."""
+    """Tracks face identities seen now and over a short lookback window.
+
+    Inputs (via :meth:`update_now`) carry an optional tier per identity:
+      - ``"confident"`` — high-confidence match (top1-top2 margin large)
+      - ``"tentative"`` — likely match but borderline; caller should verify
+      - ``"uncertain"`` / ``None`` — treated as unidentified for naming
+
+    The single-frame fields (``now``, ``unknown_now``) are unchanged so
+    legacy callers (fall-detection mapping, drawing) keep working. The new
+    tier-aware fields (``confident_now``, ``tentative_now``) drive the
+    FacePresence prompt and any robot-behavior gating.
+
+    Temporal voting note:
+      Per-track multi-frame voting is performed UPSTREAM in
+      :class:`face_tracker.FaceTracker` (3-frame majority + tier). By the
+      time names reach WhoTracker, they're already voted. This class
+      doesn't re-aggregate across frames — it just maintains a sliding
+      window for the ``recent_name_frames`` debug stats.
+    """
 
     def __init__(self, lookback_sec: float = 10.0):
         self.lookback_sec = float(lookback_sec)
-        # (ts, names[], fall_infos[])
-        self._events: Deque[Tuple[float, List[str], List[FallInfo]]] = deque(maxlen=300)
+        # (ts, names[], tiers[], fall_infos[])
+        # `tiers[i]` is the tier of `names[i]` ("confident"/"tentative"/
+        # "uncertain" or None for legacy callers).
+        self._events: Deque[Tuple[float, List[str], List[str], List[FallInfo]]] = deque(
+            maxlen=300
+        )
         self._last_now: List[str] = []
+        self._last_tiers: List[str] = []
         self._last_falls: List[FallInfo] = []
         self._lock = threading.Lock()
 
     def update_now(
         self,
         names: List[Optional[str]],
+        tiers: Optional[List[Optional[str]]] = None,
         fall_infos: Optional[List[FallInfo]] = None,
     ) -> None:
-        """Update current identities; names may include 'unknown' or None."""
+        """Update the current per-frame state.
+
+        Parameters
+        ----------
+        names : list[str | None]
+            One entry per visible face. ``"unknown"`` for unidentified faces,
+            a label like ``"wendy"`` for identified ones. ``None`` entries
+            are dropped.
+        tiers : list[str | None], optional
+            Parallel to ``names``. Each entry is one of
+            ``"confident"``, ``"tentative"``, ``"uncertain"``, or ``None``
+            (treated as "uncertain" for confident/tentative aggregation).
+            If omitted, all identified names are treated as ``"confident"``
+            for back-compat with callers that don't yet pass tier info.
+        fall_infos : list[FallInfo], optional
+            Fall-detection results aligned with ``names``.
+        """
         now_ts = time.time()
-        flat: List[str] = [n for n in names if n is not None]
+        flat_names: List[str] = []
+        flat_tiers: List[str] = []
+        for i, n in enumerate(names):
+            if n is None:
+                continue
+            flat_names.append(n)
+            if tiers is not None and i < len(tiers) and tiers[i] is not None:
+                flat_tiers.append(str(tiers[i]))
+            else:
+                # Legacy caller: assume confident for named entries, uncertain
+                # for unknowns. Matches old behavior where any named entry was
+                # treated as a positive identification.
+                flat_tiers.append(TIER_CONFIDENT if n != "unknown" else TIER_UNCERTAIN)
         falls = fall_infos or []
 
         with self._lock:
-            self._last_now = flat
+            self._last_now = flat_names
+            self._last_tiers = flat_tiers
             self._last_falls = falls
-            self._events.append((now_ts, flat, falls))
+            self._events.append((now_ts, flat_names, flat_tiers, falls))
             cutoff = now_ts - self.lookback_sec
             while self._events and self._events[0][0] < cutoff:
                 self._events.popleft()
 
     def snapshot(self, recent_sec: Optional[float] = None) -> Dict:
-        """
-        Summarize who is here now and (for recent) use max-per-frame semantics.
+        """Summarize who is here now and over the recent window.
 
-        EX: {"server_ts": 1761692303.4755309, "recent_sec": 4.0, "now": ["wendy"],
-            "unknown_now": 0, "frames_recent": 57, "frames_with_unknown": 0,
-            "recent_name_frames": {"wendy": 57}, "unknown_recent": 0}
+        Fields
+        ------
+        Per-frame (current frame only):
+          now : list[str]
+              Identified names in the latest frame (any tier). Kept for
+              back-compat with fall-detection mapping. Flickers if face
+              recognition is uncertain at frame boundaries.
+          confident_now : list[str]
+              Latest-frame names with tier "confident". Use this when you
+              want the robot to greet by name without verification.
+          tentative_now : list[str]
+              Latest-frame names with tier "tentative". Use this to prompt
+              user verification ("Are you Wendy?").
+          unknown_now : int
+              Count of unidentified faces in the latest frame.
 
-        Parameters
-        ----------
-        recent_sec : Optional[float]
-            Lookback window in seconds for recent stats. If None, uses self.lookback_sec.
+        Windowed (over ``recent_sec`` seconds):
+          frames_recent : int
+          recent_name_frames : dict[str, int]
+              How many recent frames each identified name appeared in
+              (counted ONCE per frame, any tier). Kept for the debug UI.
+          confident_frames : dict[str, int]
+              Same but counts only frames where the tier was "confident".
+          tentative_frames : dict[str, int]
+              Same but counts only frames where the tier was "tentative".
+          unknown_recent : int
+              Peak per-frame unknown count over the window.
+
+        Plus all existing fall-detection fields (unchanged).
         """
         with self._lock:
             now_list = list(self._last_now)
+            now_tiers = list(self._last_tiers)
             now_falls = list(self._last_falls)
 
             if recent_sec is None:
                 recent_sec = self.lookback_sec
             cutoff = time.time() - float(recent_sec)
-            recent_data: List[Tuple[float, List[str], List[FallInfo]]] = [
-                (ts, names, falls) for ts, names, falls in self._events if ts >= cutoff
+            recent_data: List[Tuple[float, List[str], List[str], List[FallInfo]]] = [
+                (ts, names, tiers, falls)
+                for ts, names, tiers, falls in self._events
+                if ts >= cutoff
             ]
 
         def is_named(x: str) -> bool:
             return bool(x) and x != "unknown"
 
-        # Latest frame breakdown
-        seen_in_now = set()
+        # ----- Latest-frame breakdown -----
+        seen_in_now: set = set()
         now_named: List[str] = []
-        for n in now_list:
-            if is_named(n) and n not in seen_in_now:
-                seen_in_now.add(n)
-                now_named.append(n)
+        confident_now: List[str] = []
+        tentative_now: List[str] = []
+        for name, tier in zip(now_list, now_tiers):
+            if not is_named(name) or name in seen_in_now:
+                continue
+            seen_in_now.add(name)
+            now_named.append(name)
+            if tier == TIER_CONFIDENT:
+                confident_now.append(name)
+            elif tier == TIER_TENTATIVE:
+                tentative_now.append(name)
         now_unknown = sum(1 for n in now_list if n == "unknown")
 
-        # Windowed (frames-based) stats
+        # ----- Windowed (frames-based) stats -----
         frames_recent = len(recent_data)
         frames_with_unknown = 0
         unknown_recent_peak = 0
         recent_name_frames: Dict[str, int] = {}
+        confident_frames: Dict[str, int] = {}
+        tentative_frames: Dict[str, int] = {}
 
-        for ts, frame_names, frame_falls in recent_data:
-            # Per-frame known set (dedup within the frame)
-            kset = {n for n in frame_names if is_named(n)}
-            for k in kset:
-                recent_name_frames[k] = recent_name_frames.get(k, 0) + 1
+        for _ts, frame_names, frame_tiers, _frame_falls in recent_data:
+            seen_frame: set = set()
+            seen_confident: set = set()
+            seen_tentative: set = set()
+            for name, tier in zip(frame_names, frame_tiers):
+                if not is_named(name):
+                    continue
+                # Dedup within a single frame — one face can only count once.
+                seen_frame.add(name)
+                if tier == TIER_CONFIDENT:
+                    seen_confident.add(name)
+                elif tier == TIER_TENTATIVE:
+                    seen_tentative.add(name)
+            for n in seen_frame:
+                recent_name_frames[n] = recent_name_frames.get(n, 0) + 1
+            for n in seen_confident:
+                confident_frames[n] = confident_frames.get(n, 0) + 1
+            for n in seen_tentative:
+                tentative_frames[n] = tentative_frames.get(n, 0) + 1
 
-            # Unknown presence and peak (per frame)
-            ucount = sum(1 for n in frame_names if n == "unknown")
+            ucount = sum(1 for x in frame_names if x == "unknown")
             if ucount > 0:
                 frames_with_unknown += 1
                 if ucount > unknown_recent_peak:
                     unknown_recent_peak = ucount
 
-        # Current frame fall detection
-        fallen_now = []
+        # ----- Fall detection (unchanged) -----
+        fallen_now: List[str] = []
         fallen_unknown_now = 0
         for fall in now_falls:
             if fall.is_fallen:
@@ -215,45 +321,44 @@ class WhoTracker:
                 else:
                     fallen_unknown_now += 1
 
-        # Recent frames fall detection
         frames_with_fall = 0
         fallen_recent: Dict[str, Dict] = {}
-
-        for ts, frame_names, frame_falls in recent_data:
+        for _ts, _frame_names, _frame_tiers, frame_falls in recent_data:
             frame_has_fall = False
-
             for fall in frame_falls:
                 if not fall.is_fallen:
                     continue
-
                 frame_has_fall = True
                 identity = fall.identity if fall.identity else "unknown"
-
                 if identity not in fallen_recent:
                     fallen_recent[identity] = {
                         "fallen_frames": 0,
                         "total_frames": 0,
                     }
-
                 fallen_recent[identity]["fallen_frames"] += 1
-
             if frame_has_fall:
                 frames_with_fall += 1
-
-        # Set total_frames for each identity
         for identity, stats in fallen_recent.items():
-            total = recent_name_frames.get(identity, stats["fallen_frames"])
-            stats["total_frames"] = total
+            stats["total_frames"] = recent_name_frames.get(
+                identity, stats["fallen_frames"]
+            )
 
         return {
             "server_ts": time.time(),
             "recent_sec": float(recent_sec),
+            # Per-frame
             "now": now_named,
+            "confident_now": confident_now,
+            "tentative_now": tentative_now,
             "unknown_now": int(now_unknown),
+            # Windowed
             "frames_recent": int(frames_recent),
             "frames_with_unknown": int(frames_with_unknown),
             "recent_name_frames": recent_name_frames,
+            "confident_frames": confident_frames,
+            "tentative_frames": tentative_frames,
             "unknown_recent": int(unknown_recent_peak),
+            # Fall detection (unchanged)
             "fallen_now": fallen_now,
             "fallen_now_count": len(fallen_now) + fallen_unknown_now,
             "fallen_unknown_now": fallen_unknown_now,


### PR DESCRIPTION
This pull request introduces tier-aware identity tracking and a new sample refresh manager to improve the robustness and introspection of the face recognition system. The main changes include adding a `SampleRefreshManager` for controlled gallery updates, updating `WhoTracker` to track confidence tiers for identities, and enhancing the snapshot diagnostics with tier breakdowns and improved windowed statistics.

**Tier-aware identity tracking and diagnostics:**

* `who_tracker.py`:
  - The `WhoTracker` class now tracks not just names but also confidence tiers ("confident", "tentative", "uncertain") for each identified face. This enables more granular downstream behavior (e.g., robot greeting only on "confident" matches) and richer diagnostics.
  - The `snapshot` method now includes per-frame and windowed breakdowns by tier (`confident_now`, `tentative_now`, `confident_frames`, `tentative_frames`), while preserving legacy fields for backward compatibility. [[1]](diffhunk://#diff-4ec479ca2b2d9137049a97ab039fcee2429b2103e552efa7cbb574bd20a8fda9R123-R314) [[2]](diffhunk://#diff-4ec479ca2b2d9137049a97ab039fcee2429b2103e552efa7cbb574bd20a8fda9L218-R361)
  - All event storage and processing is updated to handle parallel lists of names and tiers.

**Sample refresh management:**

* `sample_refresh.py`:
  - Introduces a new `SampleRefreshManager` class that manages when to add new samples to the face gallery. It enforces configurable guards for match confidence, per-UUID rate limiting, and diversity checks, preventing gallery pollution and resource overuse.

**Module and dependency updates:**

* `__init__.py`:
  - Adds `"selfie_logic"` to the module exports to ensure tier constants are kept in sync across modules.

These changes collectively make the face recognition pipeline more robust, introspectable, and ready for tier-aware downstream consumers.